### PR TITLE
Remove redundant calls to SetInitChainer and SetBeginBlocker

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -571,9 +571,6 @@ func New(
 	app.MountMemoryStores(memKeys)
 
 	// initialize BaseApp
-	app.SetInitChainer(app.InitChainer)
-	app.SetBeginBlocker(app.BeginBlocker)
-
 	anteHandler, err := NewAnteHandler(
 		HandlerOptions{
 			HandlerOptions: ante.HandlerOptions{


### PR DESCRIPTION
`SetInitChainer` and `SetBeginBlocker` were both being called twice, this PR removes the redundant calls.