### PR TITLE
Dont process incoming ics20 transfers for minting denom if tokenfactory is paused

### DIFF
--- a/x/tokenfactory/blockibc_middleware.go
+++ b/x/tokenfactory/blockibc_middleware.go
@@ -101,6 +101,10 @@ func (im IBCMiddleware) OnRecvPacket(
 		return im.app.OnRecvPacket(ctx, packet, relayer)
 	}
 
+	if im.keeper.GetPaused(ctx).Paused {
+		return channeltypes.NewErrorAcknowledgement(types.ErrPaused.Error())
+	}
+
 	_, found := im.keeper.GetBlacklisted(ctx, data.Receiver)
 	if found {
 		ackErr = sdkerrors.Wrapf(sdkerrors.ErrUnauthorized, "receiver address is blacklisted")


### PR DESCRIPTION
If the tokenfactory is in a paused state we want to explicitly reject incoming ics20 transfers for the minting denom