### PR TITLE
Check incoming transfers base denom against the minting denom

### DIFF
--- a/x/tokenfactory/blockibc_middleware.go
+++ b/x/tokenfactory/blockibc_middleware.go
@@ -96,8 +96,10 @@ func (im IBCMiddleware) OnRecvPacket(
 		return channeltypes.NewErrorAcknowledgement(ackErr.Error())
 	}
 
+	denomTrace := transfertypes.ParseDenomTrace(data.Denom)
+
 	mintingDenom := im.keeper.GetMintingDenom(ctx)
-	if data.Denom != mintingDenom.Denom {
+	if denomTrace.BaseDenom != mintingDenom.Denom {
 		return im.app.OnRecvPacket(ctx, packet, relayer)
 	}
 


### PR DESCRIPTION
Previously we were checking the incoming packets full denom against the minting denom so the check was always true due to the way denoms are composed in ics20 e.g. `transfer/channel-40/drachma`