### PR TITLE
Pass correct minter controller address in genesis state validation

### DIFF
--- a/x/tokenfactory/types/genesis.go
+++ b/x/tokenfactory/types/genesis.go
@@ -4,9 +4,6 @@ import (
 	"fmt"
 )
 
-// DefaultIndex is the default global index
-const DefaultIndex uint64 = 1
-
 // DefaultGenesis returns the default genesis state
 func DefaultGenesis() *GenesisState {
 	return &GenesisState{
@@ -51,7 +48,7 @@ func (gs GenesisState) Validate() error {
 	minterControllerIndexMap := make(map[string]struct{})
 
 	for _, elem := range gs.MinterControllerList {
-		index := string(MinterControllerKey(elem.Minter))
+		index := string(MinterControllerKey(elem.Controller))
 		if _, ok := minterControllerIndexMap[index]; ok {
 			return fmt.Errorf("duplicated index for minterController")
 		}

--- a/x/tokenfactory/types/genesis_test.go
+++ b/x/tokenfactory/types/genesis_test.go
@@ -56,10 +56,10 @@ func TestGenesisState_Validate(t *testing.T) {
 				},
 				MinterControllerList: []types.MinterController{
 					{
-						Minter: "0",
+						Controller: "0",
 					},
 					{
-						Minter: "1",
+						Controller: "1",
 					},
 				},
 				MintingDenom: &types.MintingDenom{


### PR DESCRIPTION
Previously we were passing the `MinterController.Minter` address in the genesis state validation but we should be using the `MinterController.Controller` address