### PR TITLE
Validate burn/mint amounts and minter allowances are greater than zero

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,9 @@ lint:
 ###                          INTERCHAINTEST (ictest)                        ###
 ###############################################################################
 
+test:
+	go test -v -race ./...
+
 ictest-tkn-factory:
 	cd interchaintest && go test -race -v -run TestNobleChain .
 
@@ -125,7 +128,7 @@ else
 	heighliner build -c noble --local -f ./chains.yaml
 endif
 
-.PHONY: all build-linux install lint \
+.PHONY: all build-linux install lint test \
 	go-mod-cache build interchaintest get-heighliner local-image \
 
 ###############################################################################

--- a/x/tokenfactory/types/message_burn.go
+++ b/x/tokenfactory/types/message_burn.go
@@ -42,5 +42,18 @@ func (msg *MsgBurn) ValidateBasic() error {
 	if err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid from address (%s)", err)
 	}
+
+	if msg.Amount.IsNil() {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, "burn amount cannot be nil")
+	}
+
+	if msg.Amount.IsNegative() {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, "burn amount cannot be negative")
+	}
+
+	if msg.Amount.IsZero() {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, "burn amount cannot be zero")
+	}
+
 	return nil
 }

--- a/x/tokenfactory/types/message_burn_test.go
+++ b/x/tokenfactory/types/message_burn_test.go
@@ -3,6 +3,7 @@ package types
 import (
 	"testing"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/strangelove-ventures/noble/testutil/sample"
 	"github.com/stretchr/testify/require"
@@ -23,7 +24,8 @@ func TestMsgBurn_ValidateBasic(t *testing.T) {
 		}, {
 			name: "valid address",
 			msg: MsgBurn{
-				From: sample.AccAddress(),
+				From:   sample.AccAddress(),
+				Amount: sdk.NewCoin("test", sdk.NewInt(1)),
 			},
 		},
 	}

--- a/x/tokenfactory/types/message_configure_minter.go
+++ b/x/tokenfactory/types/message_configure_minter.go
@@ -43,9 +43,23 @@ func (msg *MsgConfigureMinter) ValidateBasic() error {
 	if err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid from address (%s)", err)
 	}
+
 	_, err = sdk.AccAddressFromBech32(msg.Address)
 	if err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid minter address (%s)", err)
 	}
+
+	if msg.Allowance.IsNil() {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, "allowance amount cannot be nil")
+	}
+
+	if msg.Allowance.IsNegative() {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, "allowance amount cannot be negative")
+	}
+
+	if msg.Allowance.IsZero() {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, "allowance amount cannot be zero")
+	}
+
 	return nil
 }

--- a/x/tokenfactory/types/message_configure_minter_test.go
+++ b/x/tokenfactory/types/message_configure_minter_test.go
@@ -3,6 +3,7 @@ package types
 import (
 	"testing"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/strangelove-ventures/noble/testutil/sample"
 	"github.com/stretchr/testify/require"
@@ -33,8 +34,9 @@ func TestMsgConfigureMinter_ValidateBasic(t *testing.T) {
 		{
 			name: "valid address and from",
 			msg: MsgConfigureMinter{
-				From:    sample.AccAddress(),
-				Address: sample.AccAddress(),
+				From:      sample.AccAddress(),
+				Address:   sample.AccAddress(),
+				Allowance: sdk.NewCoin("test", sdk.NewInt(1)),
 			},
 		},
 	}

--- a/x/tokenfactory/types/message_mint.go
+++ b/x/tokenfactory/types/message_mint.go
@@ -43,9 +43,23 @@ func (msg *MsgMint) ValidateBasic() error {
 	if err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid from address (%s)", err)
 	}
+
 	_, err = sdk.AccAddressFromBech32(msg.Address)
 	if err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid address (%s)", err)
 	}
+
+	if msg.Amount.IsNil() {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, "mint amount cannot be nil")
+	}
+
+	if msg.Amount.IsNegative() {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, "mint amount cannot be negative")
+	}
+
+	if msg.Amount.IsZero() {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, "mint amount cannot be zero")
+	}
+
 	return nil
 }

--- a/x/tokenfactory/types/message_mint_test.go
+++ b/x/tokenfactory/types/message_mint_test.go
@@ -3,6 +3,7 @@ package types
 import (
 	"testing"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/strangelove-ventures/noble/testutil/sample"
 	"github.com/stretchr/testify/require"
@@ -35,6 +36,7 @@ func TestMsgMint_ValidateBasic(t *testing.T) {
 			msg: MsgMint{
 				From:    sample.AccAddress(),
 				Address: sample.AccAddress(),
+				Amount:  sdk.NewCoin("test", sdk.NewInt(1)),
 			},
 		},
 	}


### PR DESCRIPTION
Previously we were not validating the amounts or allowances in `MsgMint` `MsgBurn` or `MsgConfigureMinter` to be non-nil and greater than zero