### PR TITLE
Remove duplicated calls to ValidateBasic

### DIFF
--- a/x/tokenfactory/client/cli/tx_blacklist.go
+++ b/x/tokenfactory/client/cli/tx_blacklist.go
@@ -34,9 +34,7 @@ func CmdBlacklist() *cobra.Command {
 				clientCtx.GetFromAddress().String(),
 				pubBz,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
+
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}

--- a/x/tokenfactory/client/cli/tx_burn.go
+++ b/x/tokenfactory/client/cli/tx_burn.go
@@ -33,9 +33,7 @@ func CmdBurn() *cobra.Command {
 				clientCtx.GetFromAddress().String(),
 				argAmount,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
+
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}

--- a/x/tokenfactory/client/cli/tx_configure_minter.go
+++ b/x/tokenfactory/client/cli/tx_configure_minter.go
@@ -35,9 +35,7 @@ func CmdConfigureMinter() *cobra.Command {
 				argAddress,
 				argAllowance,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
+
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}

--- a/x/tokenfactory/client/cli/tx_configure_minter_controller.go
+++ b/x/tokenfactory/client/cli/tx_configure_minter_controller.go
@@ -31,9 +31,7 @@ func CmdConfigureMinterController() *cobra.Command {
 				argController,
 				argMinter,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
+
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}

--- a/x/tokenfactory/client/cli/tx_mint.go
+++ b/x/tokenfactory/client/cli/tx_mint.go
@@ -35,9 +35,7 @@ func CmdMint() *cobra.Command {
 				argAddress,
 				argAmount,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
+
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}

--- a/x/tokenfactory/client/cli/tx_pause.go
+++ b/x/tokenfactory/client/cli/tx_pause.go
@@ -27,9 +27,7 @@ func CmdPause() *cobra.Command {
 			msg := types.NewMsgPause(
 				clientCtx.GetFromAddress().String(),
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
+
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}

--- a/x/tokenfactory/client/cli/tx_remove_minter.go
+++ b/x/tokenfactory/client/cli/tx_remove_minter.go
@@ -29,9 +29,7 @@ func CmdRemoveMinter() *cobra.Command {
 				clientCtx.GetFromAddress().String(),
 				argAddress,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
+
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}

--- a/x/tokenfactory/client/cli/tx_remove_minter_controller.go
+++ b/x/tokenfactory/client/cli/tx_remove_minter_controller.go
@@ -30,9 +30,7 @@ func CmdRemoveMinterController() *cobra.Command {
 				clientCtx.GetFromAddress().String(),
 				argAddress,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
+
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}

--- a/x/tokenfactory/client/cli/tx_unblacklist.go
+++ b/x/tokenfactory/client/cli/tx_unblacklist.go
@@ -34,9 +34,7 @@ func CmdUnblacklist() *cobra.Command {
 				clientCtx.GetFromAddress().String(),
 				pubBz,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
+
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}

--- a/x/tokenfactory/client/cli/tx_unpause.go
+++ b/x/tokenfactory/client/cli/tx_unpause.go
@@ -27,9 +27,7 @@ func CmdUnpause() *cobra.Command {
 			msg := types.NewMsgUnpause(
 				clientCtx.GetFromAddress().String(),
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
+
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}

--- a/x/tokenfactory/client/cli/tx_update_blacklister.go
+++ b/x/tokenfactory/client/cli/tx_update_blacklister.go
@@ -29,9 +29,7 @@ func CmdUpdateBlacklister() *cobra.Command {
 				clientCtx.GetFromAddress().String(),
 				argAddress,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
+
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}

--- a/x/tokenfactory/client/cli/tx_update_master_minter.go
+++ b/x/tokenfactory/client/cli/tx_update_master_minter.go
@@ -29,9 +29,7 @@ func CmdUpdateMasterMinter() *cobra.Command {
 				clientCtx.GetFromAddress().String(),
 				argAddress,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
+
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}

--- a/x/tokenfactory/client/cli/tx_update_owner.go
+++ b/x/tokenfactory/client/cli/tx_update_owner.go
@@ -29,9 +29,7 @@ func CmdUpdateOwner() *cobra.Command {
 				clientCtx.GetFromAddress().String(),
 				argAddress,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
+
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}

--- a/x/tokenfactory/client/cli/tx_update_pauser.go
+++ b/x/tokenfactory/client/cli/tx_update_pauser.go
@@ -29,9 +29,7 @@ func CmdUpdatePauser() *cobra.Command {
 				clientCtx.GetFromAddress().String(),
 				argAddress,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
+
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}


### PR DESCRIPTION
`ValidateBasic` already gets called in `GenerateOrBroadcastTxCLI` so there is no reason to explicitly call it in each of the tx cli call sites