### PR TITLE
Enforce privileged role separation

### DIFF
--- a/x/tokenfactory/keeper/keeper.go
+++ b/x/tokenfactory/keeper/keeper.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"fmt"
 
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/strangelove-ventures/noble/x/tokenfactory/types"
 
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -45,4 +46,42 @@ func NewKeeper(
 
 func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 	return ctx.Logger().With("module", fmt.Sprintf("x/%s", types.ModuleName))
+}
+
+// ValidatePrivileges checks if a specified address has already been assigned to a privileged role.
+func (k Keeper) ValidatePrivileges(ctx sdk.Context, address string) error {
+	acc, err := sdk.AccAddressFromBech32(address)
+	if err != nil {
+		return err
+	}
+
+	owner, found := k.GetOwner(ctx)
+	if found {
+		if owner.Address == acc.String() {
+			return sdkerrors.Wrapf(types.ErrAlreadyPrivileged, "cannot assign (%s) to owner role", acc.String())
+		}
+	}
+
+	blacklister, found := k.GetBlacklister(ctx)
+	if found {
+		if blacklister.Address == acc.String() {
+			return sdkerrors.Wrapf(types.ErrAlreadyPrivileged, "cannot assign (%s) to black lister role", acc.String())
+		}
+	}
+
+	masterminter, found := k.GetMasterMinter(ctx)
+	if found {
+		if masterminter.Address == acc.String() {
+			return sdkerrors.Wrapf(types.ErrAlreadyPrivileged, "cannot assign (%s) to master minter role", acc.String())
+		}
+	}
+
+	pauser, found := k.GetPauser(ctx)
+	if found {
+		if pauser.Address == acc.String() {
+			return sdkerrors.Wrapf(types.ErrAlreadyPrivileged, "cannot assign (%s) to pauser role", acc.String())
+		}
+	}
+
+	return nil
 }

--- a/x/tokenfactory/keeper/keeper.go
+++ b/x/tokenfactory/keeper/keeper.go
@@ -56,31 +56,23 @@ func (k Keeper) ValidatePrivileges(ctx sdk.Context, address string) error {
 	}
 
 	owner, found := k.GetOwner(ctx)
-	if found {
-		if owner.Address == acc.String() {
-			return sdkerrors.Wrapf(types.ErrAlreadyPrivileged, "cannot assign (%s) to owner role", acc.String())
-		}
+	if found && owner.Address == acc.String() {
+		return sdkerrors.Wrapf(types.ErrAlreadyPrivileged, "cannot assign (%s) to owner role", acc.String())
 	}
 
 	blacklister, found := k.GetBlacklister(ctx)
-	if found {
-		if blacklister.Address == acc.String() {
-			return sdkerrors.Wrapf(types.ErrAlreadyPrivileged, "cannot assign (%s) to black lister role", acc.String())
-		}
+	if found && blacklister.Address == acc.String() {
+		return sdkerrors.Wrapf(types.ErrAlreadyPrivileged, "cannot assign (%s) to black lister role", acc.String())
 	}
 
 	masterminter, found := k.GetMasterMinter(ctx)
-	if found {
-		if masterminter.Address == acc.String() {
-			return sdkerrors.Wrapf(types.ErrAlreadyPrivileged, "cannot assign (%s) to master minter role", acc.String())
-		}
+	if found && masterminter.Address == acc.String() {
+		return sdkerrors.Wrapf(types.ErrAlreadyPrivileged, "cannot assign (%s) to master minter role", acc.String())
 	}
 
 	pauser, found := k.GetPauser(ctx)
-	if found {
-		if pauser.Address == acc.String() {
-			return sdkerrors.Wrapf(types.ErrAlreadyPrivileged, "cannot assign (%s) to pauser role", acc.String())
-		}
+	if found && pauser.Address == acc.String() {
+		return sdkerrors.Wrapf(types.ErrAlreadyPrivileged, "cannot assign (%s) to pauser role", acc.String())
 	}
 
 	return nil

--- a/x/tokenfactory/keeper/msg_server_update_blacklister.go
+++ b/x/tokenfactory/keeper/msg_server_update_blacklister.go
@@ -21,13 +21,19 @@ func (k msgServer) UpdateBlacklister(goCtx context.Context, msg *types.MsgUpdate
 		return nil, sdkerrors.Wrapf(types.ErrUnauthorized, "you are not the owner")
 	}
 
+	// ensure that the specified address is not already assigned to a privileged role
+	err := k.ValidatePrivileges(ctx, msg.Address)
+	if err != nil {
+		return nil, err
+	}
+
 	blacklister := types.Blacklister{
 		Address: msg.Address,
 	}
 
 	k.SetBlacklister(ctx, blacklister)
 
-	err := ctx.EventManager().EmitTypedEvent(msg)
+	err = ctx.EventManager().EmitTypedEvent(msg)
 
 	return &types.MsgUpdateBlacklisterResponse{}, err
 }

--- a/x/tokenfactory/keeper/msg_server_update_master_minter.go
+++ b/x/tokenfactory/keeper/msg_server_update_master_minter.go
@@ -21,13 +21,19 @@ func (k msgServer) UpdateMasterMinter(goCtx context.Context, msg *types.MsgUpdat
 		return nil, sdkerrors.Wrapf(types.ErrUnauthorized, "you are not the owner")
 	}
 
+	// ensure that the specified address is not already assigned to a privileged role
+	err := k.ValidatePrivileges(ctx, msg.Address)
+	if err != nil {
+		return nil, err
+	}
+
 	masterMinter := types.MasterMinter{
 		Address: msg.Address,
 	}
 
 	k.SetMasterMinter(ctx, masterMinter)
 
-	err := ctx.EventManager().EmitTypedEvent(msg)
+	err = ctx.EventManager().EmitTypedEvent(msg)
 
 	return &types.MsgUpdateMasterMinterResponse{}, err
 }

--- a/x/tokenfactory/keeper/msg_server_update_owner.go
+++ b/x/tokenfactory/keeper/msg_server_update_owner.go
@@ -21,11 +21,17 @@ func (k msgServer) UpdateOwner(goCtx context.Context, msg *types.MsgUpdateOwner)
 		return nil, sdkerrors.Wrapf(types.ErrUnauthorized, "you are not the owner")
 	}
 
+	// ensure that the specified address is not already assigned to a privileged role
+	err := k.ValidatePrivileges(ctx, msg.Address)
+	if err != nil {
+		return nil, err
+	}
+
 	owner.Address = msg.Address
 
 	k.SetOwner(ctx, owner)
 
-	err := ctx.EventManager().EmitTypedEvent(msg)
+	err = ctx.EventManager().EmitTypedEvent(msg)
 
 	return &types.MsgUpdateOwnerResponse{}, err
 }

--- a/x/tokenfactory/keeper/msg_server_update_pauser.go
+++ b/x/tokenfactory/keeper/msg_server_update_pauser.go
@@ -21,13 +21,19 @@ func (k msgServer) UpdatePauser(goCtx context.Context, msg *types.MsgUpdatePause
 		return nil, sdkerrors.Wrapf(types.ErrUnauthorized, "you are not the owner")
 	}
 
+	// ensure that the specified address is not already assigned to a privileged role
+	err := k.ValidatePrivileges(ctx, msg.Address)
+	if err != nil {
+		return nil, err
+	}
+
 	pauser := types.Pauser{
 		Address: msg.Address,
 	}
 
 	k.SetPauser(ctx, pauser)
 
-	err := ctx.EventManager().EmitTypedEvent(msg)
+	err = ctx.EventManager().EmitTypedEvent(msg)
 
 	return &types.MsgUpdatePauserResponse{}, err
 }

--- a/x/tokenfactory/types/errors.go
+++ b/x/tokenfactory/types/errors.go
@@ -17,4 +17,5 @@ var (
 	ErrInvalidPubkey      = sdkerrors.Register(ModuleName, 8, "pubkey bytes are invalid")
 	ErrMintingDenomSet    = sdkerrors.Register(ModuleName, 9, "the minting denom has already been set")
 	ErrUserBlacklisted    = sdkerrors.Register(ModuleName, 10, "user is already blacklisted")
+	ErrAlreadyPrivileged  = sdkerrors.Register(ModuleName, 11, "address is already assigned to privileged role")
 )

--- a/x/tokenfactory/types/genesis.go
+++ b/x/tokenfactory/types/genesis.go
@@ -73,43 +73,41 @@ func (gs GenesisState) Validate() error {
 		}
 	}
 
-	if gs.Owner == nil {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, "owner cannot be nil")
+	var addresses []sdk.AccAddress
+
+	if gs.Owner != nil {
+		owner, err := sdk.AccAddressFromBech32(gs.Owner.Address)
+		if err != nil {
+			return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid owner address (%s)", err)
+		}
+		addresses = append(addresses, owner)
 	}
 
-	if gs.MasterMinter == nil {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, "master minter cannot be nil")
+	if gs.MasterMinter != nil {
+		masterMinter, err := sdk.AccAddressFromBech32(gs.MasterMinter.Address)
+		if err != nil {
+			return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid master minter address (%s)", err)
+		}
+		addresses = append(addresses, masterMinter)
 	}
 
-	if gs.Pauser == nil {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, "pauser cannot be nil")
+	if gs.Pauser != nil {
+		pauser, err := sdk.AccAddressFromBech32(gs.Pauser.Address)
+		if err != nil {
+			return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid pauser address (%s)", err)
+		}
+		addresses = append(addresses, pauser)
 	}
 
-	if gs.Blacklister == nil {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, "black lister cannot be nil")
+	if gs.Blacklister != nil {
+		blacklister, err := sdk.AccAddressFromBech32(gs.Blacklister.Address)
+		if err != nil {
+			return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid black lister address (%s)", err)
+		}
+		addresses = append(addresses, blacklister)
 	}
 
-	owner, err := sdk.AccAddressFromBech32(gs.Owner.Address)
-	if err != nil {
-		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid owner address (%s)", err)
-	}
-
-	masterMinter, err := sdk.AccAddressFromBech32(gs.MasterMinter.Address)
-	if err != nil {
-		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid master minter address (%s)", err)
-	}
-
-	pauser, err := sdk.AccAddressFromBech32(gs.Pauser.Address)
-	if err != nil {
-		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid pauser address (%s)", err)
-	}
-
-	blacklister, err := sdk.AccAddressFromBech32(gs.Blacklister.Address)
-	if err != nil {
-		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid black lister address (%s)", err)
-	}
-
-	if err := validatePrivileges(owner, masterMinter, pauser, blacklister); err != nil {
+	if err := validatePrivileges(addresses); err != nil {
 		return err
 	}
 
@@ -123,7 +121,7 @@ func (gs GenesisState) Validate() error {
 }
 
 // validatePrivileges ensures that the same address is not being assigned to more than one privileged role.
-func validatePrivileges(addresses ...sdk.AccAddress) error {
+func validatePrivileges(addresses []sdk.AccAddress) error {
 	for i, current := range addresses {
 		for j, target := range addresses {
 			if i == j {

--- a/x/tokenfactory/types/genesis_test.go
+++ b/x/tokenfactory/types/genesis_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var testAddress = sample.AccAddress()
+
 func TestGenesisState_Validate(t *testing.T) {
 	for _, tc := range []struct {
 		desc     string
@@ -17,9 +19,9 @@ func TestGenesisState_Validate(t *testing.T) {
 		valid    bool
 	}{
 		{
-			desc:     "default is valid",
+			desc:     "default is invalid",
 			genState: types.DefaultGenesis(),
-			valid:    true,
+			valid:    false,
 		},
 		{
 			desc: "valid genesis state",
@@ -74,6 +76,60 @@ func TestGenesisState_Validate(t *testing.T) {
 				// this line is used by starport scaffolding # types/genesis/validField
 			},
 			valid: true,
+		},
+		{
+			desc: "invalid privilege separation",
+			genState: &types.GenesisState{
+
+				BlacklistedList: []types.Blacklisted{
+					{
+						Pubkey: []byte("0"),
+					},
+					{
+						Pubkey: []byte("1"),
+					},
+				},
+				Paused: &types.Paused{
+					Paused: true,
+				},
+				MasterMinter: &types.MasterMinter{
+					Address: testAddress,
+				},
+				MintersList: []types.Minters{
+					{
+						Address:   sample.AccAddress(),
+						Allowance: sdk.NewCoin("test", sdk.NewInt(1)),
+					},
+					{
+						Address:   sample.AccAddress(),
+						Allowance: sdk.NewCoin("test", sdk.NewInt(1)),
+					},
+				},
+				Pauser: &types.Pauser{
+					Address: testAddress,
+				},
+				Blacklister: &types.Blacklister{
+					Address: testAddress,
+				},
+				Owner: &types.Owner{
+					Address: testAddress,
+				},
+				MinterControllerList: []types.MinterController{
+					{
+						Controller: sample.AccAddress(),
+						Minter:     sample.AccAddress(),
+					},
+					{
+						Controller: sample.AccAddress(),
+						Minter:     sample.AccAddress(),
+					},
+				},
+				MintingDenom: &types.MintingDenom{
+					Denom: "test",
+				},
+				// this line is used by starport scaffolding # types/genesis/validField
+			},
+			valid: false,
 		},
 		{
 			desc: "duplicated blacklisted",

--- a/x/tokenfactory/types/genesis_test.go
+++ b/x/tokenfactory/types/genesis_test.go
@@ -19,9 +19,9 @@ func TestGenesisState_Validate(t *testing.T) {
 		valid    bool
 	}{
 		{
-			desc:     "default is invalid",
+			desc:     "default is valid",
 			genState: types.DefaultGenesis(),
-			valid:    false,
+			valid:    true,
 		},
 		{
 			desc: "valid genesis state",

--- a/x/tokenfactory/types/genesis_test.go
+++ b/x/tokenfactory/types/genesis_test.go
@@ -127,7 +127,6 @@ func TestGenesisState_Validate(t *testing.T) {
 				MintingDenom: &types.MintingDenom{
 					Denom: "test",
 				},
-				// this line is used by starport scaffolding # types/genesis/validField
 			},
 			valid: false,
 		},


### PR DESCRIPTION
This PR introduces privileged role separation by ensuring that an address cannot be assigned to more than one privileged role i.e. `Owner` `Blacklister` `Pauser` & `MasterMinter` must be different addresses. We ensure this is enforced by checking if an address has already been delegated to some role at genesis as well as during any attempts to update a role.