### PR TITLE
`denom_metadata` patch for `radon` upgrade

### DIFF
--- a/app/upgrades/radon/upgrade.go
+++ b/app/upgrades/radon/upgrade.go
@@ -26,15 +26,59 @@ func CreateRadonUpgradeHandler(
 		// becasuse RunMigrations runs `InitGenesis` on new modules`.
 		versionMap, err := mm.RunMigrations(ctx, cfg, vm)
 
+		feeDenom := fiatTFKeeper.GetMintingDenom(ctx)
+
 		// -- globalfee params --
-		minGasPrices := sdk.DecCoins{
-			sdk.NewDecCoinFromDec("udrachma", sdk.NewDecWithPrec(1, 2)),
+		globalFeeParams := globalfeetypes.Params{
+			MinimumGasPrices: sdk.DecCoins{
+				sdk.NewDecCoinFromDec(feeDenom.Denom, sdk.NewDec(0)),
+			},
+			BypassMinFeeMsgTypes: []string{
+				"/ibc.core.client.v1.MsgUpdateClient",
+				"/ibc.core.channel.v1.MsgRecvPacket",
+				"/ibc.core.channel.v1.MsgAcknowledgement",
+				"/ibc.applications.transfer.v1.MsgTransfer",
+				"/ibc.core.channel.v1.MsgTimeout",
+				"/ibc.core.channel.v1.MsgTimeoutOnClose",
+				"/cosmos.params.v1beta1.MsgUpdateParams",
+				"/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade",
+				"/cosmos.upgrade.v1beta1.MsgCancelUpgrade",
+				"/noble.fiattokenfactory.MsgUpdateMasterMinter",
+				"/noble.fiattokenfactory.MsgUpdatePauser",
+				"/noble.fiattokenfactory.MsgUpdateBlacklister",
+				"/noble.fiattokenfactory.MsgUpdateOwner",
+				"/noble.fiattokenfactory.MsgAcceptOwner",
+				"/noble.fiattokenfactory.MsgConfigureMinter",
+				"/noble.fiattokenfactory.MsgRemoveMinter",
+				"/noble.fiattokenfactory.MsgMint",
+				"/noble.fiattokenfactory.MsgBurn",
+				"/noble.fiattokenfactory.MsgBlacklist",
+				"/noble.fiattokenfactory.MsgUnblacklist",
+				"/noble.fiattokenfactory.MsgPause",
+				"/noble.fiattokenfactory.MsgUnpause",
+				"/noble.fiattokenfactory.MsgConfigureMinterController",
+				"/noble.fiattokenfactory.MsgRemoveMinterController",
+				"/noble.tokenfactory.MsgUpdatePauser",
+				"/noble.tokenfactory.MsgUpdateBlacklister",
+				"/noble.tokenfactory.MsgUpdateOwner",
+				"/noble.tokenfactory.MsgAcceptOwner",
+				"/noble.tokenfactory.MsgConfigureMinter",
+				"/noble.tokenfactory.MsgRemoveMinter",
+				"/noble.tokenfactory.MsgMint",
+				"/noble.tokenfactory.MsgBurn",
+				"/noble.tokenfactory.MsgBlacklist",
+				"/noble.tokenfactory.MsgUnblacklist",
+				"/noble.tokenfactory.MsgPause",
+				"/noble.tokenfactory.MsgUnpause",
+				"/noble.tokenfactory.MsgConfigureMinterController",
+				"/noble.tokenfactory.MsgRemoveMinterController",
+			},
 		}
 		globlaFeeParamsSubspace, ok := paramauthoritykeeper.GetSubspace(globalfeetypes.ModuleName)
 		if !ok {
 			panic("global fee params subspace not found")
 		}
-		globlaFeeParamsSubspace.Set(ctx, globalfeetypes.ParamStoreKeyMinGasPrices, minGasPrices)
+		globlaFeeParamsSubspace.SetParamSet(ctx, &globalFeeParams)
 		// -- --
 
 		// -- tariff params --
@@ -49,7 +93,6 @@ func CreateRadonUpgradeHandler(
 				Share:   sdk.NewDec(1),
 			},
 		}
-		feeDenom := fiatTFKeeper.GetMintingDenom(ctx)
 		tariffParams := tarifftypes.Params{
 			Share:                sdk.NewDecWithPrec(8, 1),
 			DistributionEntities: distributionEntities,

--- a/interchaintest/upgrade_test.go
+++ b/interchaintest/upgrade_test.go
@@ -297,13 +297,59 @@ func TestNobleChainUpgrade(t *testing.T) {
 	err = json.Unmarshal(queryResult, &globalFeeParams)
 	require.NoError(t, err, "failed to unmarshall globalfee params")
 
+	queryResult, _, err = noble.Validators[0].ExecQuery(ctx, "fiat-tokenfactory", "show-minting-denom")
+	require.NoError(t, err, "error querying minting denom")
+
+	var mintingDenomResponse fiattokenfactorytypes.QueryGetMintingDenomResponse
+	err = json.Unmarshal(queryResult, &mintingDenomResponse)
+	require.NoError(t, err, "failed to unmarshall globalfee params")
+
 	expectedMinGasPrices := sdk.DecCoins{
-		sdk.NewDecCoinFromDec("udrachma", sdk.NewDecWithPrec(1, 2)),
+		sdk.NewDecCoinFromDec(mintingDenomResponse.MintingDenom.Denom, sdk.NewDec(0)),
 	}
 	require.Equal(t, expectedMinGasPrices, globalFeeParams.MinimumGasPrices, "global fee min gas prices are not as expected")
 
-	expectedDefaultMsgTypes := globalfeetypes.DefaultParams().BypassMinFeeMsgTypes
-	require.Equal(t, expectedDefaultMsgTypes, globalFeeParams.BypassMinFeeMsgTypes, "global fee bypass message types are not as expected")
+	expectedMsgTypes := []string{
+		"/ibc.core.client.v1.MsgUpdateClient",
+		"/ibc.core.channel.v1.MsgRecvPacket",
+		"/ibc.core.channel.v1.MsgAcknowledgement",
+		"/ibc.applications.transfer.v1.MsgTransfer",
+		"/ibc.core.channel.v1.MsgTimeout",
+		"/ibc.core.channel.v1.MsgTimeoutOnClose",
+		"/cosmos.params.v1beta1.MsgUpdateParams",
+		"/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade",
+		"/cosmos.upgrade.v1beta1.MsgCancelUpgrade",
+		"/noble.fiattokenfactory.MsgUpdateMasterMinter",
+		"/noble.fiattokenfactory.MsgUpdatePauser",
+		"/noble.fiattokenfactory.MsgUpdateBlacklister",
+		"/noble.fiattokenfactory.MsgUpdateOwner",
+		"/noble.fiattokenfactory.MsgAcceptOwner",
+		"/noble.fiattokenfactory.MsgConfigureMinter",
+		"/noble.fiattokenfactory.MsgRemoveMinter",
+		"/noble.fiattokenfactory.MsgMint",
+		"/noble.fiattokenfactory.MsgBurn",
+		"/noble.fiattokenfactory.MsgBlacklist",
+		"/noble.fiattokenfactory.MsgUnblacklist",
+		"/noble.fiattokenfactory.MsgPause",
+		"/noble.fiattokenfactory.MsgUnpause",
+		"/noble.fiattokenfactory.MsgConfigureMinterController",
+		"/noble.fiattokenfactory.MsgRemoveMinterController",
+		"/noble.tokenfactory.MsgUpdatePauser",
+		"/noble.tokenfactory.MsgUpdateBlacklister",
+		"/noble.tokenfactory.MsgUpdateOwner",
+		"/noble.tokenfactory.MsgAcceptOwner",
+		"/noble.tokenfactory.MsgConfigureMinter",
+		"/noble.tokenfactory.MsgRemoveMinter",
+		"/noble.tokenfactory.MsgMint",
+		"/noble.tokenfactory.MsgBurn",
+		"/noble.tokenfactory.MsgBlacklist",
+		"/noble.tokenfactory.MsgUnblacklist",
+		"/noble.tokenfactory.MsgPause",
+		"/noble.tokenfactory.MsgUnpause",
+		"/noble.tokenfactory.MsgConfigureMinterController",
+		"/noble.tokenfactory.MsgRemoveMinterController",
+	}
+	require.Equal(t, expectedMsgTypes, globalFeeParams.BypassMinFeeMsgTypes, "global fee bypass message types are not as expected")
 
 	queryResult, _, err = noble.Validators[0].ExecQuery(ctx, "params", "subspace", "tariff", "Share")
 	require.NoError(t, err, "error querying tariff 'Share' param")


### PR DESCRIPTION
In the `globalfee` parameters,

this patch changes the fee from `0.01udrachma` to `0uusdc`

It also adds extra messages to `BypassMinFeeMsgTypes`.