### PR TITLE
Handle Zero Amount Coins to Entities

### DIFF
--- a/x/tariff/keeper/allocation.go
+++ b/x/tariff/keeper/allocation.go
@@ -19,7 +19,13 @@ func (k Keeper) AllocateTokens(ctx sdk.Context) {
 
 		for _, s := range entityShare {
 			truncated, _ := s.TruncateDecimal()
-			coins = append(coins, truncated)
+			if truncated.Amount.GT(sdk.ZeroInt()) {
+				coins = append(coins, truncated)
+			}
+		}
+
+		if len(coins) == 0 {
+			continue
 		}
 
 		acc := sdk.MustAccAddressFromBech32(d.Address)


### PR DESCRIPTION
Because of the way fees to the distribution entities were getting truncated, it was possible for the tariff module to try and distribute a zero-amount fee which would cause a consensus failure. 

Specifically if the IBC transaction was between 10,000 - 19,999.