### PR TITLE
Log error instead of panic during BeginBlocker token allocations

### DIFF
--- a/x/tariff/keeper/allocation.go
+++ b/x/tariff/keeper/allocation.go
@@ -27,7 +27,7 @@ func (k Keeper) AllocateTokens(ctx sdk.Context) {
 		// transfer collected fees to the distribution entity account
 		err := k.bankKeeper.SendCoinsFromModuleToAccount(ctx, k.feeCollectorName, acc, coins)
 		if err != nil {
-			panic(err)
+			ctx.Logger().Error("Error allocating tokens to distribution entity: %s "+err.Error(), d.Address)
 		}
 	}
 }


### PR DESCRIPTION
This avoids a chain halt in the rare case there is an error distributing fees to the distribution entities. 