### PR TITLE
Make more efficient if zero fees to distribute

### DIFF
--- a/x/tariff/keeper/allocation.go
+++ b/x/tariff/keeper/allocation.go
@@ -7,6 +7,17 @@ import (
 func (k Keeper) AllocateTokens(ctx sdk.Context) {
 	feeCollector := k.authKeeper.GetModuleAccount(ctx, k.feeCollectorName)
 	feesCollectedInt := k.bankKeeper.GetAllBalances(ctx, feeCollector.GetAddress())
+	foundAmountGreaterThanZero := false
+	for _, coin := range feesCollectedInt {
+		if coin.Amount.GT(sdk.ZeroInt()) {
+			foundAmountGreaterThanZero = true
+			break
+		}
+	}
+	if !foundAmountGreaterThanZero {
+		// no fees to distribute
+		return
+	}
 	feesCollected := sdk.NewDecCoinsFromCoins(feesCollectedInt...)
 
 	params := k.GetParams(ctx)

--- a/x/tariff/keeper/allocation.go
+++ b/x/tariff/keeper/allocation.go
@@ -11,7 +11,7 @@ func (k Keeper) AllocateTokens(ctx sdk.Context) {
 
 	params := k.GetParams(ctx)
 	feesToDistribute := feesCollected.MulDecTruncate(params.Share)
-	if feesToDistribute.AmountOf(params.TransferFeeDenom).IsZero() {
+	if params.TransferFeeDenom == "" || feesToDistribute.AmountOf(params.TransferFeeDenom).IsZero() {
 		return
 	}
 

--- a/x/tariff/keeper/allocation.go
+++ b/x/tariff/keeper/allocation.go
@@ -22,7 +22,17 @@ func (k Keeper) AllocateTokens(ctx sdk.Context) {
 
 	params := k.GetParams(ctx)
 	feesToDistribute := feesCollected.MulDecTruncate(params.Share)
-	if feesToDistribute.AmountOf(params.TransferFeeDenom).IsZero() {
+
+	foundAmountGreaterThanZero = false
+	for _, coin := range feesToDistribute {
+		truncated, _ := coin.TruncateDecimal()
+		if truncated.Amount.GT(sdk.ZeroInt()) {
+			foundAmountGreaterThanZero = true
+			break
+		}
+	}
+	if !foundAmountGreaterThanZero {
+		// no fees to distribute
 		return
 	}
 

--- a/x/tariff/keeper/allocation.go
+++ b/x/tariff/keeper/allocation.go
@@ -11,6 +11,9 @@ func (k Keeper) AllocateTokens(ctx sdk.Context) {
 
 	params := k.GetParams(ctx)
 	feesToDistribute := feesCollected.MulDecTruncate(params.Share)
+	if feesToDistribute.AmountOf(params.TransferFeeDenom).IsZero() {
+		return
+	}
 
 	for _, d := range params.DistributionEntities {
 		entityShare := feesToDistribute.MulDecTruncate(d.Share)

--- a/x/tariff/keeper/allocation.go
+++ b/x/tariff/keeper/allocation.go
@@ -11,7 +11,7 @@ func (k Keeper) AllocateTokens(ctx sdk.Context) {
 
 	params := k.GetParams(ctx)
 	feesToDistribute := feesCollected.MulDecTruncate(params.Share)
-	if params.TransferFeeDenom == "" || feesToDistribute.AmountOf(params.TransferFeeDenom).IsZero() {
+	if feesToDistribute.AmountOf(params.TransferFeeDenom).IsZero() {
 		return
 	}
 


### PR DESCRIPTION
In the Tariff module, if there are zero fees to distribute, there is no need to loop through all the distribution entities to divide out a zero amount. 