### PR TITLE
version fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ DOCKER_BUF := $(DOCKER) run --rm -v $(CURDIR):/workspace --workdir /workspace bu
 
 # don't override user values
 ifeq (,$(VERSION))
-  VERSION := $(shell git describe --exact-match 2>/dev/null)
+  VERSION := $(shell echo $(shell git describe --tags) | sed 's/^v//')
   # if VERSION is empty, then populate it with branch's name and raw commit hash
   ifeq (,$(VERSION))
     VERSION := $(BRANCH)-$(COMMIT)


### PR DESCRIPTION
This change allows noble to report the proper version when running nobled version.  I believe the issue was git describe --exact-match returns...
fatal: no tag exactly matches '55d62161961a10e0c5c3174b42676ca3d3be1eae'