### PR TITLE
ibc client authority

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -42,7 +42,7 @@ jobs:
     strategy:
         matrix:
             # names of `make` commands to run tests
-            test: ["ictest-tkn-factory", "ictest-packet-forward", "ictest-paramauthority", "ictest-chain-upgrade-noble-1", "ictest-chain-upgrade-grand-1", "ictest-globalFee", "ictest-ics20-bps-fees"]
+            test: ["ictest-tkn-factory", "ictest-packet-forward", "ictest-paramauthority", "ictest-chain-upgrade-noble-1", "ictest-chain-upgrade-grand-1", "ictest-globalFee", "ictest-ics20-bps-fees", "ictest-client-substitution"]
         fail-fast: false
 
     steps:

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Build Docker image
         uses: strangelove-ventures/heighliner-build-action@v0.0.3
         with:
-          registry: # empty registry, image only shared for e2e testing
+          registry: "" # empty registry, image only shared for e2e testing
           tag: local # emulate local environment for consistency in interchaintest cases
           tar-export-path: ${{ env.TAR_PATH }} # export a tarball that can be uploaded as an artifact for the e2e jobs
           platform: linux/amd64 # test runner architecture only

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,9 @@ ictest-globalFee:
 
 ictest-ics20-bps-fees:
 	cd interchaintest && go test -race -v -run ^TestICS20BPSFees$$ .
-	
+
+ictest-client-substitution:
+	cd interchaintest && go test -race -v -run ^TestClientSubstitution$$ .
 
 ###############################################################################
 ###                                Build Image                              ###

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,6 +28,8 @@ import (
 	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	paramauthorityibccli "github.com/strangelove-ventures/paramauthority/x/ibc/client/cli"
+	paramauthorityparamscli "github.com/strangelove-ventures/paramauthority/x/params/client/cli"
 	paramauthorityupgradecli "github.com/strangelove-ventures/paramauthority/x/upgrade/client/cli"
 	tmcli "github.com/tendermint/tendermint/libs/cli"
 	"github.com/tendermint/tendermint/libs/log"
@@ -283,6 +285,12 @@ func txCommand(moduleBasics module.BasicManager) *cobra.Command {
 		RunE:                       client.ValidateCmd,
 	}
 
+	upgradeCmd := paramauthorityupgradecli.GetTxCmd()
+	upgradeCmd.AddCommand(
+		paramauthorityibccli.NewCmdSubmitUpdateClientProposal(),
+		paramauthorityibccli.NewCmdSubmitUpgradeProposal(),
+	)
+
 	cmd.AddCommand(
 		authcmd.GetSignCommand(),
 		authcmd.GetSignBatchCommand(),
@@ -292,7 +300,8 @@ func txCommand(moduleBasics module.BasicManager) *cobra.Command {
 		authcmd.GetBroadcastCommand(),
 		authcmd.GetEncodeCommand(),
 		authcmd.GetDecodeCommand(),
-		paramauthorityupgradecli.GetTxCmd(),
+		upgradeCmd,
+		paramauthorityparamscli.GetTxCmd(),
 	)
 
 	moduleBasics.AddTxCommands(cmd)

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
 	github.com/strangelove-ventures/packet-forward-middleware/v3 v3.1.5
-	github.com/strangelove-ventures/paramauthority v0.1.3-0.20230706162329-b52649a2b986
+	github.com/strangelove-ventures/paramauthority v0.2.0
 	github.com/stretchr/testify v1.8.1
 	github.com/tendermint/tendermint v0.34.27
 	github.com/tendermint/tm-db v0.6.7

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
 	github.com/strangelove-ventures/packet-forward-middleware/v3 v3.1.5
-	github.com/strangelove-ventures/paramauthority v0.1.1
+	github.com/strangelove-ventures/paramauthority v0.1.3-0.20230706162329-b52649a2b986
 	github.com/stretchr/testify v1.8.1
 	github.com/tendermint/tendermint v0.34.27
 	github.com/tendermint/tm-db v0.6.7

--- a/go.sum
+++ b/go.sum
@@ -938,8 +938,8 @@ github.com/spf13/viper v1.14.0/go.mod h1:WT//axPky3FdvXHzGw33dNdXXXfFQqmEalje+eg
 github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4/go.mod h1:RZLeN1LMWmRsyYjvAu+I6Dm9QmlDaIIt+Y+4Kd7Tp+Q=
 github.com/strangelove-ventures/packet-forward-middleware/v3 v3.1.5 h1:iXXjziCSAebzuRUPFSnqD7epSDB8LEPgkh9zhbj7ha4=
 github.com/strangelove-ventures/packet-forward-middleware/v3 v3.1.5/go.mod h1:ncgsf5rykh36HkM16BNcKKx1XzVRdWXt+4pph1syDHE=
-github.com/strangelove-ventures/paramauthority v0.1.3-0.20230706162329-b52649a2b986 h1:LG+1rSceLHkf+gfvUmfWKccnkNEELRXHk0rt//EDuv0=
-github.com/strangelove-ventures/paramauthority v0.1.3-0.20230706162329-b52649a2b986/go.mod h1:31HVpoItQMa4Wj2BimVhQWbIYeb+kdUDJ8MzBEbGj28=
+github.com/strangelove-ventures/paramauthority v0.2.0 h1:h/ApdnvwV0gAjgQAFJ0Z2U6xuARvBnpmzhkvJRdkJZU=
+github.com/strangelove-ventures/paramauthority v0.2.0/go.mod h1:31HVpoItQMa4Wj2BimVhQWbIYeb+kdUDJ8MzBEbGj28=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=

--- a/go.sum
+++ b/go.sum
@@ -750,9 +750,9 @@ github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxzi
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/neilotoole/errgroup v0.1.6/go.mod h1:Q2nLGf+594h0CLBs/Mbg6qOr7GtqDK7C2S41udRnToE=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/noble-assets/ibc-go/v3 v3.4.0-huckleberry h1:02oo/GHLGITexbPNUO/jmYa67xE+B5BvNv/i+wufdHI=
 github.com/noble-assets/ibc-go/v3 v3.4.0-huckleberry/go.mod h1:VwB/vWu4ysT5DN2aF78d17LYmx3omSAdq6gpKvM7XRA=
+github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
@@ -938,8 +938,8 @@ github.com/spf13/viper v1.14.0/go.mod h1:WT//axPky3FdvXHzGw33dNdXXXfFQqmEalje+eg
 github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4/go.mod h1:RZLeN1LMWmRsyYjvAu+I6Dm9QmlDaIIt+Y+4Kd7Tp+Q=
 github.com/strangelove-ventures/packet-forward-middleware/v3 v3.1.5 h1:iXXjziCSAebzuRUPFSnqD7epSDB8LEPgkh9zhbj7ha4=
 github.com/strangelove-ventures/packet-forward-middleware/v3 v3.1.5/go.mod h1:ncgsf5rykh36HkM16BNcKKx1XzVRdWXt+4pph1syDHE=
-github.com/strangelove-ventures/paramauthority v0.1.1 h1:rvAnF+dTRMG+rHmD9LL8OWbxu1uFgo0Zi+JZ6cQ+I60=
-github.com/strangelove-ventures/paramauthority v0.1.1/go.mod h1:PHq/b8q6YfBDJpo34RlnWw+cL5m5Bids2prBUWzsoEM=
+github.com/strangelove-ventures/paramauthority v0.1.3-0.20230706162329-b52649a2b986 h1:LG+1rSceLHkf+gfvUmfWKccnkNEELRXHk0rt//EDuv0=
+github.com/strangelove-ventures/paramauthority v0.1.3-0.20230706162329-b52649a2b986/go.mod h1:31HVpoItQMa4Wj2BimVhQWbIYeb+kdUDJ8MzBEbGj28=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=

--- a/interchaintest/go.mod
+++ b/interchaintest/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/icza/dyno v0.0.0-20220812133438-f0b6f8a18845
 	github.com/strangelove-ventures/interchaintest/v3 v3.0.0-20230622221919-28c608364e27
 	github.com/strangelove-ventures/noble v0.0.0-00010101000000-000000000000
-	github.com/strangelove-ventures/paramauthority v0.1.3-0.20230706162329-b52649a2b986
+	github.com/strangelove-ventures/paramauthority v0.2.0
 	github.com/stretchr/testify v1.8.4
 	go.uber.org/zap v1.24.0
 )

--- a/interchaintest/go.mod
+++ b/interchaintest/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/icza/dyno v0.0.0-20220812133438-f0b6f8a18845
 	github.com/strangelove-ventures/interchaintest/v3 v3.0.0-20230622221919-28c608364e27
 	github.com/strangelove-ventures/noble v0.0.0-00010101000000-000000000000
-	github.com/strangelove-ventures/paramauthority v0.1.1
+	github.com/strangelove-ventures/paramauthority v0.1.3-0.20230706162329-b52649a2b986
 	github.com/stretchr/testify v1.8.4
 	go.uber.org/zap v1.24.0
 )

--- a/interchaintest/go.sum
+++ b/interchaintest/go.sum
@@ -987,8 +987,8 @@ github.com/spf13/viper v1.15.0/go.mod h1:fFcTBJxvhhzSJiZy8n+PeW6t8l+KeT/uTARa0jH
 github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4/go.mod h1:RZLeN1LMWmRsyYjvAu+I6Dm9QmlDaIIt+Y+4Kd7Tp+Q=
 github.com/strangelove-ventures/interchaintest/v3 v3.0.0-20230622221919-28c608364e27 h1:oJ9yZIFp3yRTlH8BOLnACrsjR1fPIpHyOoLFjM5VRBc=
 github.com/strangelove-ventures/interchaintest/v3 v3.0.0-20230622221919-28c608364e27/go.mod h1:dWv7E8XtgidmA/A5Gy9x76qMIygES+SxPTnlWjYUb7g=
-github.com/strangelove-ventures/paramauthority v0.1.3-0.20230706162329-b52649a2b986 h1:LG+1rSceLHkf+gfvUmfWKccnkNEELRXHk0rt//EDuv0=
-github.com/strangelove-ventures/paramauthority v0.1.3-0.20230706162329-b52649a2b986/go.mod h1:31HVpoItQMa4Wj2BimVhQWbIYeb+kdUDJ8MzBEbGj28=
+github.com/strangelove-ventures/paramauthority v0.2.0 h1:h/ApdnvwV0gAjgQAFJ0Z2U6xuARvBnpmzhkvJRdkJZU=
+github.com/strangelove-ventures/paramauthority v0.2.0/go.mod h1:31HVpoItQMa4Wj2BimVhQWbIYeb+kdUDJ8MzBEbGj28=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=

--- a/interchaintest/go.sum
+++ b/interchaintest/go.sum
@@ -987,8 +987,8 @@ github.com/spf13/viper v1.15.0/go.mod h1:fFcTBJxvhhzSJiZy8n+PeW6t8l+KeT/uTARa0jH
 github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4/go.mod h1:RZLeN1LMWmRsyYjvAu+I6Dm9QmlDaIIt+Y+4Kd7Tp+Q=
 github.com/strangelove-ventures/interchaintest/v3 v3.0.0-20230622221919-28c608364e27 h1:oJ9yZIFp3yRTlH8BOLnACrsjR1fPIpHyOoLFjM5VRBc=
 github.com/strangelove-ventures/interchaintest/v3 v3.0.0-20230622221919-28c608364e27/go.mod h1:dWv7E8XtgidmA/A5Gy9x76qMIygES+SxPTnlWjYUb7g=
-github.com/strangelove-ventures/paramauthority v0.1.1 h1:rvAnF+dTRMG+rHmD9LL8OWbxu1uFgo0Zi+JZ6cQ+I60=
-github.com/strangelove-ventures/paramauthority v0.1.1/go.mod h1:PHq/b8q6YfBDJpo34RlnWw+cL5m5Bids2prBUWzsoEM=
+github.com/strangelove-ventures/paramauthority v0.1.3-0.20230706162329-b52649a2b986 h1:LG+1rSceLHkf+gfvUmfWKccnkNEELRXHk0rt//EDuv0=
+github.com/strangelove-ventures/paramauthority v0.1.3-0.20230706162329-b52649a2b986/go.mod h1:31HVpoItQMa4Wj2BimVhQWbIYeb+kdUDJ8MzBEbGj28=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=

--- a/interchaintest/ibc_client_expire_substitute_test.go
+++ b/interchaintest/ibc_client_expire_substitute_test.go
@@ -57,7 +57,7 @@ func TestClientSubstitution(t *testing.T) {
 			if err != nil {
 				return err
 			}
-			err = createTokenfactoryRoles(ctx, &roles2, denomMetadataDrachma, val, false)
+			err = createTokenfactoryRoles(ctx, &roles2, denomMetadataDrachma, val, true)
 			if err != nil {
 				return err
 			}

--- a/interchaintest/ibc_client_expire_substitute_test.go
+++ b/interchaintest/ibc_client_expire_substitute_test.go
@@ -53,7 +53,7 @@ func TestClientSubstitution(t *testing.T) {
 		EncodingConfig: NobleEncoding(),
 		PreGenesis: func(cc ibc.ChainConfig) (err error) {
 			val := noble.Validators[0]
-			err = createTokenfactoryRoles(ctx, &roles, denomMetadataRupee, val, false)
+			err = createTokenfactoryRoles(ctx, &roles, denomMetadataRupee, val, true)
 			if err != nil {
 				return err
 			}

--- a/interchaintest/ibc_client_expire_substitute_test.go
+++ b/interchaintest/ibc_client_expire_substitute_test.go
@@ -221,6 +221,9 @@ func TestClientUnfreeze(t *testing.T) {
 	_, err = noble.Validators[0].ExecTx(ctx, paramauthorityWallet.KeyName(), "upgrade", "update-client", nobleClient.ClientID, newNobleClient.ClientID)
 	require.NoError(t, err)
 
+	err = testutil.WaitForBlocks(ctx, 5, noble)
+	require.NoError(t, err)
+
 	// start up relayer and test a transfer on the new client
 	err = r.StartRelayer(ctx, eRep, pathName)
 	require.NoError(t, err)

--- a/interchaintest/ibc_client_unfreeze_test.go
+++ b/interchaintest/ibc_client_unfreeze_test.go
@@ -1,0 +1,202 @@
+package interchaintest_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/strangelove-ventures/interchaintest/v3"
+	"github.com/strangelove-ventures/interchaintest/v3/chain/cosmos"
+	"github.com/strangelove-ventures/interchaintest/v3/ibc"
+	"github.com/strangelove-ventures/interchaintest/v3/testreporter"
+	"github.com/strangelove-ventures/interchaintest/v3/testutil"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+)
+
+// run `make local-image`to rebuild updated binary before running test
+func TestClientUnfreeze(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	t.Parallel()
+
+	ctx := context.Background()
+
+	rep := testreporter.NewNopReporter()
+	eRep := rep.RelayerExecReporter(t)
+
+	client, network := interchaintest.DockerSetup(t)
+
+	var (
+		noble                *cosmos.CosmosChain
+		roles                NobleRoles
+		roles2               NobleRoles
+		paramauthorityWallet ibc.Wallet
+	)
+
+	chainCfg := ibc.ChainConfig{
+		Type:           "cosmos",
+		Name:           "noble",
+		ChainID:        "noble-1",
+		Bin:            "nobled",
+		Denom:          "token",
+		Bech32Prefix:   "noble",
+		CoinType:       "118",
+		GasPrices:      "0.0token",
+		GasAdjustment:  1.1,
+		TrustingPeriod: "504h",
+		NoHostMount:    false,
+		Images:         nobleImageInfo,
+		EncodingConfig: NobleEncoding(),
+		PreGenesis: func(cc ibc.ChainConfig) (err error) {
+			val := noble.Validators[0]
+			err = createTokenfactoryRoles(ctx, &roles, denomMetadataRupee, val, false)
+			if err != nil {
+				return err
+			}
+			err = createTokenfactoryRoles(ctx, &roles2, denomMetadataDrachma, val, false)
+			if err != nil {
+				return err
+			}
+			paramauthorityWallet, err = createParamAuthAtGenesis(ctx, val)
+			return err
+		},
+		ModifyGenesis: func(cc ibc.ChainConfig, b []byte) ([]byte, error) {
+			g := make(map[string]interface{})
+			if err := json.Unmarshal(b, &g); err != nil {
+				return nil, fmt.Errorf("failed to unmarshal genesis file: %w", err)
+			}
+			if err := modifyGenesisTokenfactory(g, "tokenfactory", denomMetadataRupee, &roles, true); err != nil {
+				return nil, err
+			}
+			if err := modifyGenesisTokenfactory(g, "fiat-tokenfactory", denomMetadataDrachma, &roles2, true); err != nil {
+				return nil, err
+			}
+			if err := modifyGenesisParamAuthority(g, paramauthorityWallet.FormattedAddress()); err != nil {
+				return nil, err
+			}
+			if err := modifyGenesisTariffDefaults(g, paramauthorityWallet.FormattedAddress()); err != nil {
+				return nil, err
+			}
+			out, err := json.Marshal(&g)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal genesis bytes to json: %w", err)
+			}
+			return out, nil
+		},
+	}
+
+	nv := 1
+	nf := 0
+
+	cf := interchaintest.NewBuiltinChainFactory(zaptest.NewLogger(t), []*interchaintest.ChainSpec{
+		{
+			ChainConfig:   chainCfg,
+			NumValidators: &nv,
+			NumFullNodes:  &nf,
+		},
+		{
+			Name:          "gaia",
+			Version:       "v10.0.2",
+			NumValidators: &nv,
+			NumFullNodes:  &nf,
+		},
+	})
+
+	chains, err := cf.Chains(t.Name())
+	require.NoError(t, err)
+
+	noble = chains[0].(*cosmos.CosmosChain)
+	gaia := chains[1].(*cosmos.CosmosChain)
+
+	r := interchaintest.NewBuiltinRelayerFactory(
+		ibc.CosmosRly,
+		zaptest.NewLogger(t),
+		relayerImage,
+	).Build(t, client, network)
+
+	pathName := "noble-gaia"
+
+	ic := interchaintest.NewInterchain().
+		AddChain(noble).
+		AddChain(gaia).
+		AddRelayer(r, "r").
+		AddLink(interchaintest.InterchainLink{
+			Chain1:  noble,
+			Chain2:  gaia,
+			Relayer: r,
+			Path:    pathName,
+			CreateClientOpts: ibc.CreateClientOptions{
+				TrustingPeriod: "20s",
+			},
+		})
+
+	require.NoError(t, ic.Build(ctx, eRep, interchaintest.InterchainBuildOptions{
+		TestName:  t.Name(),
+		Client:    client,
+		NetworkID: network,
+
+		// TODO comment out for CI
+		BlockDatabaseFile: interchaintest.DefaultBlockDatabaseFilepath(),
+
+		SkipPathCreation: true,
+	}))
+	t.Cleanup(func() {
+		_ = ic.Close()
+	})
+
+	const userFunds = int64(10_000_000_000)
+	users := interchaintest.GetAndFundTestUsers(t, ctx, t.Name(), userFunds, noble, gaia)
+
+	nobleChainID := noble.Config().ChainID
+
+	nobleClients, err := r.GetClients(ctx, eRep, nobleChainID)
+	require.NoError(t, err)
+	require.Len(t, nobleClients, 1)
+
+	nobleClient := nobleClients[0]
+
+	nobleChannels, err := r.GetChannels(ctx, eRep, nobleChainID)
+	require.NoError(t, err)
+	require.Len(t, nobleChannels, 1)
+	nobleChannel := nobleChannels[0]
+
+	err = testutil.WaitForBlocks(ctx, 20, noble)
+	require.NoError(t, err)
+
+	// client should now be expired, no relayer was running to update the clients during the 20s trusting period.
+
+	_, err = noble.SendIBCTransfer(ctx, nobleChannel.ChannelID, users[0].KeyName(), ibc.WalletAmount{
+		Address: users[1].FormattedAddress(),
+		Amount:  1000000,
+		Denom:   noble.Config().Denom,
+	}, ibc.TransferOptions{})
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "status Expired: client is not active")
+
+	// create new client
+	require.NoError(t, r.CreateClients(ctx, eRep, pathName, ibc.CreateClientOptions{TrustingPeriod: "1h", Override: true}))
+
+	nobleClients, err = r.GetClients(ctx, eRep, nobleChainID)
+	require.NoError(t, err)
+	require.Len(t, nobleClients, 2)
+
+	newNobleClient := nobleClients[1]
+
+	// substitute new client for old client
+	_, err = noble.Validators[0].ExecTx(ctx, paramauthorityWallet.KeyName(), "upgrade", "update-client", nobleClient.ClientID, newNobleClient.ClientID)
+	require.NoError(t, err)
+
+	// send a packet on the same channel but new client, should succeed.
+	_, err = noble.SendIBCTransfer(ctx, nobleChannel.ChannelID, users[0].KeyName(), ibc.WalletAmount{
+		Address: users[1].FormattedAddress(),
+		Amount:  1000000,
+		Denom:   noble.Config().Denom,
+	}, ibc.TransferOptions{})
+	require.NoError(t, err)
+
+}


### PR DESCRIPTION
Add capability for IBC proposals (client substitution and ibc upgrade) to be executed by the upgrade authority.

2 new msgs (`MsgClientUpdate`, `MsgUpgrade`), msg handlers, and CLI commands.

`MsgClientUpdate` allows the upgrade authority to substitute a new light client state into an existing one, allowing recovery of expired clients.