### PR TITLE
chore: prepare `v3.1.0` release

### DIFF
--- a/.changelog/config.toml
+++ b/.changelog/config.toml
@@ -1,0 +1,1 @@
+project_url = "https://github.com/strangelove-ventures/noble"

--- a/.changelog/epilogue.md
+++ b/.changelog/epilogue.md
@@ -1,0 +1,5 @@
+---
+
+## Previous Changes
+
+This changelog has yet to be fully initialized. For previous verions please refer to the release notes for a summary of changes.

--- a/.changelog/v3.1.0/features/235-ibc-authority.md
+++ b/.changelog/v3.1.0/features/235-ibc-authority.md
@@ -1,0 +1,1 @@
+- Include support for IBC inside the ParamAuthority. ([#235](https://github.com/strangelove-ventures/noble/pull/235))

--- a/.changelog/v3.1.0/improvements/234-module-path.md
+++ b/.changelog/v3.1.0/improvements/234-module-path.md
@@ -1,0 +1,1 @@
+- Align module path with Go's [naming convention](https://go.dev/doc/modules/version-numbers#major-version). ([#234](https://github.com/strangelove-ventures/noble/pull/234))

--- a/.changelog/v3.1.0/summary.md
+++ b/.changelog/v3.1.0/summary.md
@@ -1,0 +1,5 @@
+*Sep 15, 2023*
+
+This is a minor release to the v3 Radon line.
+
+In response to multiple IBC channels expiring on Noble's mainnet network, it was decided to expand the functionality of Noble's Maintenance Multisig to include IBC upgrade functionality (allowing expired clients to be changed).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# CHANGELOG
+
+## v3.1.0
+
+*Sep 15, 2023*
+
+This is a minor release to the v3 Radon line.
+
+In response to multiple IBC channels expiring on Noble's mainnet network, it was decided to expand the functionality of Noble's Maintenance Multisig to include IBC upgrade functionality (allowing expired clients to be changed).
+
+### FEATURES
+
+- Include support for IBC inside the ParamAuthority. ([#235](https://github.com/strangelove-ventures/noble/pull/235))
+
+### IMPROVEMENTS
+
+- Align module path with Go's [naming convention](https://go.dev/doc/modules/version-numbers#major-version). ([#234](https://github.com/strangelove-ventures/noble/pull/234))
+
+---
+
+## Previous Changes
+
+This changelog has yet to be fully initialized. For previous verions please refer to the release notes for a summary of changes.
+

--- a/app/app.go
+++ b/app/app.go
@@ -90,8 +90,9 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/staking"
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-	neon "github.com/strangelove-ventures/noble/v3/app/upgrades/neon"
-	radon "github.com/strangelove-ventures/noble/v3/app/upgrades/radon"
+	"github.com/strangelove-ventures/noble/v3/app/upgrades/neon"
+	"github.com/strangelove-ventures/noble/v3/app/upgrades/radon"
+	v3m1p0 "github.com/strangelove-ventures/noble/v3/app/upgrades/v3.1.0"
 	"github.com/strangelove-ventures/noble/v3/cmd"
 	"github.com/strangelove-ventures/noble/v3/docs"
 	"github.com/strangelove-ventures/noble/v3/x/blockibc"
@@ -866,6 +867,14 @@ func (app *App) setupUpgradeHandlers() {
 			app.FiatTokenFactoryKeeper,
 		))
 
+	// v3.1.0 upgrade
+	app.UpgradeKeeper.SetUpgradeHandler(
+		v3m1p0.UpgradeName,
+		v3m1p0.CreateV3M1P0UpgradeHandler(
+			app.mm,
+			app.configurator,
+		))
+
 	upgradeInfo, err := app.UpgradeKeeper.ReadUpgradeInfoFromDisk()
 	if err != nil {
 		panic(fmt.Errorf("failed to read upgrade info from disk: %w", err))
@@ -885,6 +894,8 @@ func (app *App) setupUpgradeHandlers() {
 		stroreUpgrades = &storetypes.StoreUpgrades{
 			Added: []string{globalfeetypes.ModuleName, tarifftypes.ModuleName},
 		}
+	case v3m1p0.UpgradeName:
+		stroreUpgrades = &storetypes.StoreUpgrades{}
 	}
 
 	if stroreUpgrades != nil {

--- a/app/upgrades/v3.1.0/constants.go
+++ b/app/upgrades/v3.1.0/constants.go
@@ -1,0 +1,6 @@
+package v3m1p0
+
+const (
+	// UpgradeName is the name of this specific software upgrade used on-chain.
+	UpgradeName = "v3.1.0"
+)

--- a/app/upgrades/v3.1.0/upgrade.go
+++ b/app/upgrades/v3.1.0/upgrade.go
@@ -1,0 +1,16 @@
+package v3m1p0
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	upgradeTypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+)
+
+func CreateV3M1P0UpgradeHandler(
+	mm *module.Manager,
+	cfg module.Configurator,
+) upgradeTypes.UpgradeHandler {
+	return func(ctx sdk.Context, _ upgradeTypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		return mm.RunMigrations(ctx, cfg, vm)
+	}
+}

--- a/interchaintest/upgrade_grand-1_test.go
+++ b/interchaintest/upgrade_grand-1_test.go
@@ -46,7 +46,15 @@ func TestGrand1ChainUpgrade(t *testing.T) {
 		},
 		{
 			// post radon patch upgrade (will be applied as rolling upgrade due to lack of upgradeName)
-			image: nobleImageInfo[0],
+			image: ibc.DockerImage{
+				Repository: "ghcr.io/strangelove-ventures/noble",
+				Version:    "v3.0.0",
+				UidGid:     containerUidGid,
+			},
+		},
+		{
+			upgradeName: "v3.1.0",
+			image:       nobleImageInfo[0],
 		},
 	}
 

--- a/interchaintest/upgrade_noble-1_test.go
+++ b/interchaintest/upgrade_noble-1_test.go
@@ -40,8 +40,16 @@ func TestNoble1ChainUpgrade(t *testing.T) {
 		},
 		{
 			upgradeName: "radon",
-			image:       nobleImageInfo[0],
+			image: ibc.DockerImage{
+				Repository: "ghcr.io/strangelove-ventures/noble",
+				Version:    "v3.0.0",
+				UidGid:     containerUidGid,
+			},
 			postUpgrade: testPostRadonUpgrade,
+		},
+		{
+			upgradeName: "v3.1.0",
+			image:       nobleImageInfo[0],
 		},
 	}
 


### PR DESCRIPTION
[Rendered CHANGELOG](https://github.com/strangelove-ventures/noble/blob/john/prepare-v3.1/CHANGELOG.md)

Note that this builds on top of #234 and #235, which should be merged first.