### PR TITLE
Add AppModuleBasic for ibc authority

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -146,6 +146,7 @@ var (
 		packetforward.AppModuleBasic{},
 		globalfee.AppModuleBasic{},
 		tariff.AppModuleBasic{},
+		paramauthorityibc.AppModuleBasic{},
 	)
 
 	// module account permissions
@@ -604,9 +605,6 @@ func New(
 
 	// Uncomment if you want to set a custom migration order here.
 	// app.mm.SetOrderMigrations(custom order)
-
-	// Register interfaces for paramauthority ibc proposal shim
-	paramauthorityibctypes.RegisterInterfaces(interfaceRegistry)
 
 	app.mm.RegisterInvariants(&app.CrisisKeeper)
 	app.mm.RegisterRoutes(app.Router(), app.QueryRouter(), encodingConfig.Amino)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -285,12 +285,6 @@ func txCommand(moduleBasics module.BasicManager) *cobra.Command {
 		RunE:                       client.ValidateCmd,
 	}
 
-	upgradeCmd := paramauthorityupgradecli.GetTxCmd()
-	upgradeCmd.AddCommand(
-		paramauthorityibccli.NewCmdSubmitUpdateClientProposal(),
-		paramauthorityibccli.NewCmdSubmitUpgradeProposal(),
-	)
-
 	cmd.AddCommand(
 		authcmd.GetSignCommand(),
 		authcmd.GetSignBatchCommand(),
@@ -301,7 +295,8 @@ func txCommand(moduleBasics module.BasicManager) *cobra.Command {
 		authcmd.GetEncodeCommand(),
 		authcmd.GetDecodeCommand(),
 		paramauthorityparamscli.GetTxCmd(),
-		upgradeCmd,
+		paramauthorityupgradecli.GetTxCmd(),
+		paramauthorityibccli.GetTxCmd(),
 	)
 
 	moduleBasics.AddTxCommands(cmd)

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
 	github.com/strangelove-ventures/packet-forward-middleware/v3 v3.1.5
-	github.com/strangelove-ventures/paramauthority v0.2.0
+	github.com/strangelove-ventures/paramauthority v0.2.1-0.20230915144245-28bb74cf85c5
 	github.com/stretchr/testify v1.8.1
 	github.com/tendermint/tendermint v0.34.27
 	github.com/tendermint/tm-db v0.6.7

--- a/go.sum
+++ b/go.sum
@@ -940,6 +940,8 @@ github.com/strangelove-ventures/packet-forward-middleware/v3 v3.1.5 h1:iXXjziCSA
 github.com/strangelove-ventures/packet-forward-middleware/v3 v3.1.5/go.mod h1:ncgsf5rykh36HkM16BNcKKx1XzVRdWXt+4pph1syDHE=
 github.com/strangelove-ventures/paramauthority v0.2.0 h1:h/ApdnvwV0gAjgQAFJ0Z2U6xuARvBnpmzhkvJRdkJZU=
 github.com/strangelove-ventures/paramauthority v0.2.0/go.mod h1:31HVpoItQMa4Wj2BimVhQWbIYeb+kdUDJ8MzBEbGj28=
+github.com/strangelove-ventures/paramauthority v0.2.1-0.20230915144245-28bb74cf85c5 h1:bikYenP6xGeVg4bLe/P+y+Bk8SJReH+AP6T8mgJYKHA=
+github.com/strangelove-ventures/paramauthority v0.2.1-0.20230915144245-28bb74cf85c5/go.mod h1:31HVpoItQMa4Wj2BimVhQWbIYeb+kdUDJ8MzBEbGj28=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=

--- a/interchaintest/go.mod
+++ b/interchaintest/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/icza/dyno v0.0.0-20220812133438-f0b6f8a18845
 	github.com/strangelove-ventures/interchaintest/v3 v3.0.0-20230622221919-28c608364e27
 	github.com/strangelove-ventures/noble/v3 v3.0.0-00010101000000-000000000000
-	github.com/strangelove-ventures/paramauthority v0.2.0
+	github.com/strangelove-ventures/paramauthority v0.2.1-0.20230915144245-28bb74cf85c5
 	github.com/stretchr/testify v1.8.4
 	go.uber.org/zap v1.24.0
 )

--- a/interchaintest/go.sum
+++ b/interchaintest/go.sum
@@ -987,8 +987,8 @@ github.com/spf13/viper v1.15.0/go.mod h1:fFcTBJxvhhzSJiZy8n+PeW6t8l+KeT/uTARa0jH
 github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4/go.mod h1:RZLeN1LMWmRsyYjvAu+I6Dm9QmlDaIIt+Y+4Kd7Tp+Q=
 github.com/strangelove-ventures/interchaintest/v3 v3.0.0-20230622221919-28c608364e27 h1:oJ9yZIFp3yRTlH8BOLnACrsjR1fPIpHyOoLFjM5VRBc=
 github.com/strangelove-ventures/interchaintest/v3 v3.0.0-20230622221919-28c608364e27/go.mod h1:dWv7E8XtgidmA/A5Gy9x76qMIygES+SxPTnlWjYUb7g=
-github.com/strangelove-ventures/paramauthority v0.2.0 h1:h/ApdnvwV0gAjgQAFJ0Z2U6xuARvBnpmzhkvJRdkJZU=
-github.com/strangelove-ventures/paramauthority v0.2.0/go.mod h1:31HVpoItQMa4Wj2BimVhQWbIYeb+kdUDJ8MzBEbGj28=
+github.com/strangelove-ventures/paramauthority v0.2.1-0.20230915144245-28bb74cf85c5 h1:bikYenP6xGeVg4bLe/P+y+Bk8SJReH+AP6T8mgJYKHA=
+github.com/strangelove-ventures/paramauthority v0.2.1-0.20230915144245-28bb74cf85c5/go.mod h1:31HVpoItQMa4Wj2BimVhQWbIYeb+kdUDJ8MzBEbGj28=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=

--- a/interchaintest/ibc_substitute_expired_client_test.go
+++ b/interchaintest/ibc_substitute_expired_client_test.go
@@ -212,7 +212,7 @@ func TestClientSubstitution(t *testing.T) {
 	newNobleClient := nobleClients[1]
 
 	// substitute new client state into old client
-	_, err = noble.Validators[0].ExecTx(ctx, paramauthorityWallet.KeyName(), "upgrade", "update-client", nobleClient.ClientID, newNobleClient.ClientID)
+	_, err = noble.Validators[0].ExecTx(ctx, paramauthorityWallet.KeyName(), "ibc-authority", "update-client", nobleClient.ClientID, newNobleClient.ClientID)
 	require.NoError(t, err)
 
 	// update config to old client ID


### PR DESCRIPTION
The CLI client substitution command was not working due to an unregistered codec. Fix in paramauthority: https://github.com/strangelove-ventures/paramauthority/pull/16