### PR TITLE
chore: backport CCTP changes to v3 release line

### DIFF
--- a/.changelog/v3.1.1/improvements/251-cctp-interface-changes.md
+++ b/.changelog/v3.1.1/improvements/251-cctp-interface-changes.md
@@ -1,0 +1,1 @@
+- Add `x/fiattokenfactory` interface changes required for [CCTP](https://www.circle.com/en/cross-chain-transfer-protocol). ([#251](https://github.com/strangelove-ventures/noble/pull/251))

--- a/.changelog/v3.1.1/summary.md
+++ b/.changelog/v3.1.1/summary.md
@@ -1,0 +1,5 @@
+*Oct 20, 2023*
+
+This is a patch release to the v3.1 Radon line.
+
+It includes a non-consensus breaking change to the `x/fiattokenfactory` module. This change allows the `Burn` and `Mint` methods to be called from other modules. Please note that the same permissions still apply to these methods.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # CHANGELOG
 
+## v3.1.1
+
+*Oct 20, 2023*
+
+This is a patch release to the v3.1 Radon line.
+
+It includes a non-consensus breaking change to the `x/fiattokenfactory` module. This change allows the `Burn` and `Mint` methods to be called from other modules. Please note that the same permissions still apply to these methods.
+
+### IMPROVEMENTS
+
+- Add `x/fiattokenfactory` interface changes required for [CCTP](https://www.circle.com/en/cross-chain-transfer-protocol). ([#251](https://github.com/strangelove-ventures/noble/pull/251))
+
 ## v3.1.0
 
 *Sep 15, 2023*

--- a/x/fiattokenfactory/keeper/msg_server_burn.go
+++ b/x/fiattokenfactory/keeper/msg_server_burn.go
@@ -12,7 +12,10 @@ import (
 
 func (k msgServer) Burn(goCtx context.Context, msg *types.MsgBurn) (*types.MsgBurnResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
+	return k.Keeper.Burn(ctx, msg)
+}
 
+func (k Keeper) Burn(ctx sdk.Context, msg *types.MsgBurn) (*types.MsgBurnResponse, error) {
 	_, found := k.GetMinters(ctx, msg.From)
 	if !found {
 		return nil, sdkerrors.Wrapf(types.ErrBurn, "%v: you are not a minter", types.ErrUnauthorized)

--- a/x/fiattokenfactory/keeper/msg_server_mint.go
+++ b/x/fiattokenfactory/keeper/msg_server_mint.go
@@ -13,7 +13,10 @@ import (
 
 func (k msgServer) Mint(goCtx context.Context, msg *types.MsgMint) (*types.MsgMintResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
+	return k.Keeper.Mint(ctx, msg)
+}
 
+func (k Keeper) Mint(ctx sdk.Context, msg *types.MsgMint) (*types.MsgMintResponse, error) {
 	minter, found := k.GetMinters(ctx, msg.From)
 	if !found {
 		return nil, sdkerrors.Wrapf(types.ErrUnauthorized, "you are not a minter")

--- a/x/fiattokenfactory/module_simulation.go
+++ b/x/fiattokenfactory/module_simulation.go
@@ -8,6 +8,8 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/cosmos/cosmos-sdk/x/simulation"
 	"github.com/strangelove-ventures/noble/v3/testutil/sample"
 	tokenfactorysimulation "github.com/strangelove-ventures/noble/v3/x/fiattokenfactory/simulation"
@@ -85,15 +87,51 @@ const (
 
 // GenerateGenesisState creates a randomized GenState of the module
 func (AppModule) GenerateGenesisState(simState *module.SimulationState) {
-	accs := make([]string, len(simState.Accounts))
-	for i, acc := range simState.Accounts {
-		accs[i] = acc.Address.String()
+	// x/fiattokenfactory
+
+	genesis := types.GenesisState{
+		MintersList: []types.Minters{
+			{
+				Address: authtypes.NewModuleAddress("cctp").String(),
+			},
+		},
+		MinterControllerList: []types.MinterController{
+			{
+				Minter: authtypes.NewModuleAddress("cctp").String(),
+			},
+		},
+		MintingDenom: &types.MintingDenom{Denom: "uusdc"},
 	}
-	tokenfactoryGenesis := types.GenesisState{
-		Params: types.DefaultParams(),
-		// this line is used by starport scaffolding # simapp/module/genesisState
-	}
-	simState.GenState[types.ModuleName] = simState.Cdc.MustMarshalJSON(&tokenfactoryGenesis)
+
+	simState.GenState[types.ModuleName] = simState.Cdc.MustMarshalJSON(&genesis)
+
+	// x/bank
+
+	bankGenesisBz := simState.GenState[banktypes.ModuleName]
+	var bankGenesis banktypes.GenesisState
+	simState.Cdc.MustUnmarshalJSON(bankGenesisBz, &bankGenesis)
+
+	bankGenesis.DenomMetadata = append(bankGenesis.DenomMetadata, banktypes.Metadata{
+		Description: "USD Coin",
+		DenomUnits: []*banktypes.DenomUnit{
+			{
+				Denom:    "uusdc",
+				Exponent: 0,
+				Aliases:  []string{"microusdc"},
+			},
+			{
+				Denom:    "usdc",
+				Exponent: 6,
+				Aliases:  []string{},
+			},
+		},
+		Base:    "uusdc",
+		Display: "usdc",
+		Name:    "usdc",
+		Symbol:  "USDC",
+	})
+
+	simState.GenState[banktypes.ModuleName] = simState.Cdc.MustMarshalJSON(&bankGenesis)
 }
 
 // ProposalContents doesn't return any content functions for governance proposals


### PR DESCRIPTION
This PR backports the interface changes to the `x/fiattokenfactory` module required by CCTP.

As this is a non-consensus breaking change, this will be released as a patch to the `v3.1.0` release line.