### PR TITLE
Mock tests for v4.0.0

### DIFF
--- a/interchaintest/cctp_deposit_for_burn_test.go
+++ b/interchaintest/cctp_deposit_for_burn_test.go
@@ -78,12 +78,12 @@ func TestCCTP_DepositForBurn(t *testing.T) {
 	require.NoError(t, err, "failed to execute configure minter controller tx")
 
 	_, err = nobleValidator.ExecTx(ctx, gw.fiatTfRoles.MinterController.KeyName(),
-		"fiat-tokenfactory", "configure-minter", gw.fiatTfRoles.Minter.FormattedAddress(), "1000000000000"+denomMetadataDrachma.Base, "-b", "block",
+		"fiat-tokenfactory", "configure-minter", gw.fiatTfRoles.Minter.FormattedAddress(), "1000000000000"+denomMetadataUsdc.Base, "-b", "block",
 	)
 	require.NoError(t, err, "failed to execute configure minter tx")
 
 	_, err = nobleValidator.ExecTx(ctx, gw.fiatTfRoles.Minter.KeyName(),
-		"fiat-tokenfactory", "mint", gw.extraWallets.User.FormattedAddress(), "1000000000000"+denomMetadataDrachma.Base, "-b", "block",
+		"fiat-tokenfactory", "mint", gw.extraWallets.User.FormattedAddress(), "1000000000000"+denomMetadataUsdc.Base, "-b", "block",
 	)
 	require.NoError(t, err, "failed to execute mint to user tx")
 
@@ -93,7 +93,7 @@ func TestCCTP_DepositForBurn(t *testing.T) {
 	require.NoError(t, err, "failed to configure cctp minter controller")
 
 	_, err = nobleValidator.ExecTx(ctx, gw.fiatTfRoles.MinterController.KeyName(),
-		"fiat-tokenfactory", "configure-minter", cctptypes.ModuleAddress.String(), "1000000000000"+denomMetadataDrachma.Base, "-b", "block",
+		"fiat-tokenfactory", "configure-minter", cctptypes.ModuleAddress.String(), "1000000000000"+denomMetadataUsdc.Base, "-b", "block",
 	)
 	require.NoError(t, err, "failed to configure cctp minter")
 
@@ -122,7 +122,7 @@ func TestCCTP_DepositForBurn(t *testing.T) {
 		From:         gw.fiatTfRoles.Owner.FormattedAddress(),
 		RemoteDomain: 0,
 		RemoteToken:  burnToken,
-		LocalToken:   denomMetadataDrachma.Base,
+		LocalToken:   denomMetadataUsdc.Base,
 	})
 
 	bCtx, bCancel := context.WithTimeout(ctx, 20*time.Second)
@@ -137,7 +137,7 @@ func TestCCTP_DepositForBurn(t *testing.T) {
 	require.NoError(t, err, "error configuring remote domain")
 	require.Zero(t, tx.Code, "configuring remote domain failed: %s - %s - %s", tx.Codespace, tx.RawLog, tx.Data)
 
-	beforeBurnBal, err := noble.GetBalance(ctx, gw.extraWallets.User.FormattedAddress(), denomMetadataDrachma.Base)
+	beforeBurnBal, err := noble.GetBalance(ctx, gw.extraWallets.User.FormattedAddress(), denomMetadataUsdc.Base)
 	require.NoError(t, err)
 
 	mintRecipient := make([]byte, 32)
@@ -146,7 +146,7 @@ func TestCCTP_DepositForBurn(t *testing.T) {
 	depositForBurnNoble := &cctptypes.MsgDepositForBurn{
 		From:              gw.extraWallets.User.FormattedAddress(),
 		Amount:            cosmossdk_io_math.NewInt(1000000),
-		BurnToken:         denomMetadataDrachma.Base,
+		BurnToken:         denomMetadataUsdc.Base,
 		DestinationDomain: 0,
 		MintRecipient:     mintRecipient,
 	}
@@ -160,7 +160,7 @@ func TestCCTP_DepositForBurn(t *testing.T) {
 	require.NoError(t, err, "error broadcasting msgDepositForBurn")
 	require.Zero(t, tx.Code, "msgDepositForBurn failed: %s - %s - %s", tx.Codespace, tx.RawLog, tx.Data)
 
-	afterBurnBal, err := noble.GetBalance(ctx, gw.extraWallets.User.FormattedAddress(), denomMetadataDrachma.Base)
+	afterBurnBal, err := noble.GetBalance(ctx, gw.extraWallets.User.FormattedAddress(), denomMetadataUsdc.Base)
 	require.NoError(t, err)
 
 	require.Equal(t, afterBurnBal, beforeBurnBal-1000000)
@@ -173,7 +173,7 @@ func TestCCTP_DepositForBurn(t *testing.T) {
 			depositForBurn, ok := parsedEvent.(*cctptypes.DepositForBurn)
 			require.True(t, ok)
 
-			expectedBurnToken := hex.EncodeToString(crypto.Keccak256([]byte(denomMetadataDrachma.Base)))
+			expectedBurnToken := hex.EncodeToString(crypto.Keccak256([]byte(denomMetadataUsdc.Base)))
 
 			require.Equal(t, uint64(0), depositForBurn.Nonce)
 			require.Equal(t, expectedBurnToken, depositForBurn.BurnToken)

--- a/interchaintest/cctp_deposit_for_burn_with_caller_test.go
+++ b/interchaintest/cctp_deposit_for_burn_with_caller_test.go
@@ -78,12 +78,12 @@ func TestCCTP_DepositForBurnWithCaller(t *testing.T) {
 	require.NoError(t, err, "failed to execute configure minter controller tx")
 
 	_, err = nobleValidator.ExecTx(ctx, gw.fiatTfRoles.MinterController.KeyName(),
-		"fiat-tokenfactory", "configure-minter", gw.fiatTfRoles.Minter.FormattedAddress(), "1000000000000"+denomMetadataDrachma.Base, "-b", "block",
+		"fiat-tokenfactory", "configure-minter", gw.fiatTfRoles.Minter.FormattedAddress(), "1000000000000"+denomMetadataUsdc.Base, "-b", "block",
 	)
 	require.NoError(t, err, "failed to execute configure minter tx")
 
 	_, err = nobleValidator.ExecTx(ctx, gw.fiatTfRoles.Minter.KeyName(),
-		"fiat-tokenfactory", "mint", gw.extraWallets.User.FormattedAddress(), "1000000000000"+denomMetadataDrachma.Base, "-b", "block",
+		"fiat-tokenfactory", "mint", gw.extraWallets.User.FormattedAddress(), "1000000000000"+denomMetadataUsdc.Base, "-b", "block",
 	)
 	require.NoError(t, err, "failed to execute mint to user tx")
 
@@ -93,7 +93,7 @@ func TestCCTP_DepositForBurnWithCaller(t *testing.T) {
 	require.NoError(t, err, "failed to configure cctp minter controller")
 
 	_, err = nobleValidator.ExecTx(ctx, gw.fiatTfRoles.MinterController.KeyName(),
-		"fiat-tokenfactory", "configure-minter", cctptypes.ModuleAddress.String(), "1000000000000"+denomMetadataDrachma.Base, "-b", "block",
+		"fiat-tokenfactory", "configure-minter", cctptypes.ModuleAddress.String(), "1000000000000"+denomMetadataUsdc.Base, "-b", "block",
 	)
 	require.NoError(t, err, "failed to configure cctp minter")
 
@@ -122,7 +122,7 @@ func TestCCTP_DepositForBurnWithCaller(t *testing.T) {
 		From:         gw.fiatTfRoles.Owner.FormattedAddress(),
 		RemoteDomain: 0,
 		RemoteToken:  burnToken,
-		LocalToken:   denomMetadataDrachma.Base,
+		LocalToken:   denomMetadataUsdc.Base,
 	})
 
 	bCtx, bCancel := context.WithTimeout(ctx, 20*time.Second)
@@ -137,7 +137,7 @@ func TestCCTP_DepositForBurnWithCaller(t *testing.T) {
 	require.NoError(t, err, "error configuring remote domain")
 	require.Zero(t, tx.Code, "configuring remote domain failed: %s - %s - %s", tx.Codespace, tx.RawLog, tx.Data)
 
-	beforeBurnBal, err := noble.GetBalance(ctx, gw.extraWallets.User.FormattedAddress(), denomMetadataDrachma.Base)
+	beforeBurnBal, err := noble.GetBalance(ctx, gw.extraWallets.User.FormattedAddress(), denomMetadataUsdc.Base)
 	require.NoError(t, err)
 
 	mintRecipient := make([]byte, 32)
@@ -148,7 +148,7 @@ func TestCCTP_DepositForBurnWithCaller(t *testing.T) {
 	depositForBurnWithCallerNoble := &cctptypes.MsgDepositForBurnWithCaller{
 		From:              gw.extraWallets.User.FormattedAddress(),
 		Amount:            cosmossdk_io_math.NewInt(1000000),
-		BurnToken:         denomMetadataDrachma.Base,
+		BurnToken:         denomMetadataUsdc.Base,
 		DestinationDomain: 0,
 		MintRecipient:     mintRecipient,
 		DestinationCaller: destinationCaller,
@@ -163,7 +163,7 @@ func TestCCTP_DepositForBurnWithCaller(t *testing.T) {
 	require.NoError(t, err, "error broadcasting msgDepositForBurnWithCaller")
 	require.Zero(t, tx.Code, "msgDepositForBurnWithCaller failed: %s - %s - %s", tx.Codespace, tx.RawLog, tx.Data)
 
-	afterBurnBal, err := noble.GetBalance(ctx, gw.extraWallets.User.FormattedAddress(), denomMetadataDrachma.Base)
+	afterBurnBal, err := noble.GetBalance(ctx, gw.extraWallets.User.FormattedAddress(), denomMetadataUsdc.Base)
 	require.NoError(t, err)
 
 	require.Equal(t, afterBurnBal, beforeBurnBal-1000000)
@@ -176,7 +176,7 @@ func TestCCTP_DepositForBurnWithCaller(t *testing.T) {
 			depositForBurn, ok := parsedEvent.(*cctptypes.DepositForBurn)
 			require.True(t, ok)
 
-			expectedBurnToken := hex.EncodeToString(crypto.Keccak256([]byte(denomMetadataDrachma.Base)))
+			expectedBurnToken := hex.EncodeToString(crypto.Keccak256([]byte(denomMetadataUsdc.Base)))
 
 			require.Equal(t, uint64(0), depositForBurn.Nonce)
 			require.Equal(t, expectedBurnToken, depositForBurn.BurnToken)

--- a/interchaintest/cctp_receive_message_test.go
+++ b/interchaintest/cctp_receive_message_test.go
@@ -111,7 +111,7 @@ func TestCCTP_ReceiveMessage(t *testing.T) {
 		From:         gw.fiatTfRoles.Owner.FormattedAddress(),
 		RemoteDomain: 0,
 		RemoteToken:  burnToken,
-		LocalToken:   denomMetadataDrachma.Base,
+		LocalToken:   denomMetadataUsdc.Base,
 	})
 
 	bCtx, bCancel := context.WithTimeout(ctx, 20*time.Second)
@@ -128,7 +128,7 @@ func TestCCTP_ReceiveMessage(t *testing.T) {
 
 	t.Logf("Submitted add public keys tx: %s", tx.TxHash)
 
-	bCtx, bCancel = context.WithTimeout(ctx, 20*time.Second)
+	_, bCancel = context.WithTimeout(ctx, 20*time.Second)
 	defer bCancel()
 
 	nobleValidator := noble.Validators[0]
@@ -141,7 +141,7 @@ func TestCCTP_ReceiveMessage(t *testing.T) {
 	require.NoError(t, err, "failed to execute configure minter controller tx")
 
 	_, err = nobleValidator.ExecTx(ctx, gw.fiatTfRoles.MinterController.KeyName(),
-		"fiat-tokenfactory", "configure-minter", cctpModuleAccount, "1000000"+denomMetadataDrachma.Base, "-b", "block",
+		"fiat-tokenfactory", "configure-minter", cctpModuleAccount, "1000000"+denomMetadataUsdc.Base, "-b", "block",
 	)
 	require.NoError(t, err, "failed to execute configure minter tx")
 
@@ -222,7 +222,7 @@ func TestCCTP_ReceiveMessage(t *testing.T) {
 
 	t.Logf("CCTP burn message successfully received: %s", tx.TxHash)
 
-	balance, err := noble.GetBalance(ctx, nobleReceiver, denomMetadataDrachma.Base)
+	balance, err := noble.GetBalance(ctx, nobleReceiver, denomMetadataUsdc.Base)
 	require.NoError(t, err)
 
 	require.Equal(t, int64(1000000), balance)

--- a/interchaintest/cctp_receive_message_with_caller_test.go
+++ b/interchaintest/cctp_receive_message_with_caller_test.go
@@ -111,7 +111,7 @@ func TestCCTP_ReceiveMessageWithCaller(t *testing.T) {
 		From:         gw.fiatTfRoles.Owner.FormattedAddress(),
 		RemoteDomain: 0,
 		RemoteToken:  burnToken,
-		LocalToken:   denomMetadataDrachma.Base,
+		LocalToken:   denomMetadataUsdc.Base,
 	})
 
 	bCtx, bCancel := context.WithTimeout(ctx, 20*time.Second)
@@ -128,7 +128,7 @@ func TestCCTP_ReceiveMessageWithCaller(t *testing.T) {
 
 	t.Logf("Submitted add public keys tx: %s", tx.TxHash)
 
-	bCtx, bCancel = context.WithTimeout(ctx, 20*time.Second)
+	_, bCancel = context.WithTimeout(ctx, 20*time.Second)
 	defer bCancel()
 
 	nobleValidator := noble.Validators[0]
@@ -141,7 +141,7 @@ func TestCCTP_ReceiveMessageWithCaller(t *testing.T) {
 	require.NoError(t, err, "failed to execute configure minter controller tx")
 
 	_, err = nobleValidator.ExecTx(ctx, gw.fiatTfRoles.MinterController.KeyName(),
-		"fiat-tokenfactory", "configure-minter", cctpModuleAccount, "1000000"+denomMetadataDrachma.Base, "-b", "block",
+		"fiat-tokenfactory", "configure-minter", cctpModuleAccount, "1000000"+denomMetadataUsdc.Base, "-b", "block",
 	)
 	require.NoError(t, err, "failed to execute configure minter tx")
 
@@ -223,7 +223,7 @@ func TestCCTP_ReceiveMessageWithCaller(t *testing.T) {
 
 	t.Logf("CCTP burn message successfully received: %s", tx.TxHash)
 
-	balance, err := noble.GetBalance(ctx, nobleReceiver, denomMetadataDrachma.Base)
+	balance, err := noble.GetBalance(ctx, nobleReceiver, denomMetadataUsdc.Base)
 	require.NoError(t, err)
 
 	require.Equal(t, int64(1000000), balance)

--- a/interchaintest/cctp_replace_deposit_for_burn_test.go
+++ b/interchaintest/cctp_replace_deposit_for_burn_test.go
@@ -119,7 +119,7 @@ func TestCCTP_ReplaceDepositForBurn(t *testing.T) {
 		From:         gw.fiatTfRoles.Owner.FormattedAddress(),
 		RemoteDomain: 0,
 		RemoteToken:  burnToken,
-		LocalToken:   denomMetadataDrachma.Base,
+		LocalToken:   denomMetadataUsdc.Base,
 	})
 
 	bCtx, bCancel := context.WithTimeout(ctx, 20*time.Second)
@@ -146,7 +146,7 @@ func TestCCTP_ReplaceDepositForBurn(t *testing.T) {
 	require.NoError(t, err, "failed to execute configure minter controller tx")
 
 	_, err = nobleValidator.ExecTx(ctx, gw.fiatTfRoles.MinterController.KeyName(),
-		"fiat-tokenfactory", "configure-minter", cctpModuleAccount, "1000000"+denomMetadataDrachma.Base, "-b", "block",
+		"fiat-tokenfactory", "configure-minter", cctpModuleAccount, "1000000"+denomMetadataUsdc.Base, "-b", "block",
 	)
 	require.NoError(t, err, "failed to execute configure minter tx")
 

--- a/interchaintest/genesis_test.go
+++ b/interchaintest/genesis_test.go
@@ -56,55 +56,20 @@ var (
 		},
 	}
 
-	denomMetadataRupee = DenomMetadata{
-		Display: "rupee",
-		Base:    "urupee",
-		Name:    "rupee",
-		Symbol:  "RUPEE",
+	denomMetadataUsdc = DenomMetadata{
+		Display: "usdc",
+		Name:    "usdc",
+		Base:    "uusdc",
 		DenomUnits: []DenomUnit{
 			{
-				Denom: "urupee",
+				Denom: "uusdc",
 				Aliases: []string{
-					"microrupee",
+					"microusdc",
 				},
 				Exponent: "0",
 			},
 			{
-				Denom: "mrupee",
-				Aliases: []string{
-					"millirupee",
-				},
-				Exponent: "3",
-			},
-			{
-				Denom:    "rupee",
-				Exponent: "6",
-			},
-		},
-	}
-
-	denomMetadataDrachma = DenomMetadata{
-		Display: "drachma",
-		Base:    "udrachma",
-		Name:    "drachma",
-		Symbol:  "DRACHMA",
-		DenomUnits: []DenomUnit{
-			{
-				Denom: "udrachma",
-				Aliases: []string{
-					"microdrachma",
-				},
-				Exponent: "0",
-			},
-			{
-				Denom: "mdrachma",
-				Aliases: []string{
-					"millidrachma",
-				},
-				Exponent: "3",
-			},
-			{
-				Denom:    "drachma",
+				Denom:    "usdc",
 				Exponent: "6",
 			},
 		},
@@ -114,7 +79,7 @@ var (
 	defaultDistributionEntityShare = "1.0"
 	defaultTransferBPSFee          = "1"
 	defaultTransferMaxFee          = "5000000"
-	defaultTransferFeeDenom        = denomMetadataDrachma.Base
+	defaultTransferFeeDenom        = denomMetadataUsdc.Base
 
 	relayerImage = relayer.CustomDockerImage("ghcr.io/cosmos/relayer", "v2.4.1", rly.RlyDefaultUidGid)
 )
@@ -443,12 +408,12 @@ func preGenesisAll(ctx context.Context, gw *genesisWrapper, minSetupTf, minSetup
 	return func(cc ibc.ChainConfig) (err error) {
 		val := gw.chain.Validators[0]
 
-		gw.tfRoles, err = createTokenfactoryRoles(ctx, denomMetadataRupee, val, minSetupTf)
+		gw.tfRoles, err = createTokenfactoryRoles(ctx, denomMetadataFrienzies, val, minSetupTf)
 		if err != nil {
 			return err
 		}
 
-		gw.fiatTfRoles, err = createTokenfactoryRoles(ctx, denomMetadataDrachma, val, minSetupFiatTf)
+		gw.fiatTfRoles, err = createTokenfactoryRoles(ctx, denomMetadataUsdc, val, minSetupFiatTf)
 		if err != nil {
 			return err
 		}
@@ -472,11 +437,11 @@ func modifyGenesisAll(gw *genesisWrapper, minSetupTf, minSetupFiatTf bool) func(
 			return nil, fmt.Errorf("failed to unmarshal genesis file: %w", err)
 		}
 
-		if err := modifyGenesisTokenfactory(g, "tokenfactory", denomMetadataRupee, gw.tfRoles, minSetupTf); err != nil {
+		if err := modifyGenesisTokenfactory(g, "tokenfactory", denomMetadataFrienzies, gw.tfRoles, minSetupTf); err != nil {
 			return nil, err
 		}
 
-		if err := modifyGenesisTokenfactory(g, "fiat-tokenfactory", denomMetadataDrachma, gw.fiatTfRoles, minSetupFiatTf); err != nil {
+		if err := modifyGenesisTokenfactory(g, "fiat-tokenfactory", denomMetadataUsdc, gw.fiatTfRoles, minSetupFiatTf); err != nil {
 			return nil, err
 		}
 
@@ -570,7 +535,7 @@ func modifyGenesisCCTP(genbz map[string]interface{}, authority string) error {
 	if err := dyno.Set(genbz, authority, "app_state", "cctp", "token_controller"); err != nil {
 		return fmt.Errorf("failed to set cctp authority address in genesis json: %w", err)
 	}
-	if err := dyno.Set(genbz, []CCTPPerMessageBurnLimit{{Amount: "99999999", Denom: denomMetadataDrachma.Base}}, "app_state", "cctp", "per_message_burn_limit_list"); err != nil {
+	if err := dyno.Set(genbz, []CCTPPerMessageBurnLimit{{Amount: "99999999", Denom: denomMetadataUsdc.Base}}, "app_state", "cctp", "per_message_burn_limit_list"); err != nil {
 		return fmt.Errorf("failed to set cctp perMessageBurnLimit in genesis json: %w", err)
 	}
 	if err := dyno.Set(genbz, CCTPAmount{Amount: "8000"}, "app_state", "cctp", "max_message_body_size"); err != nil {

--- a/interchaintest/genesis_test.go
+++ b/interchaintest/genesis_test.go
@@ -289,7 +289,8 @@ func createTokenfactoryRoles(ctx context.Context, denomMetadata DenomMetadata, v
 func createParamAuthAtGenesis(ctx context.Context, val *cosmos.ChainNode) (ibc.Wallet, error) {
 	chainCfg := val.Chain.Config()
 
-	wallet, err := val.Chain.BuildWallet(ctx, "authority", "")
+	// Test address: noble127de05h6z3a3rh5jf0rjepa48zpgxtesfywgtf
+	wallet, err := val.Chain.BuildWallet(ctx, "authority", "index grain inform faith cave know pluck avoid supply zoo retreat system perfect aware shuffle abuse fat security cash amount night return grape candy")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create wallet: %w", err)
 	}

--- a/interchaintest/ibc_bps_fee_test.go
+++ b/interchaintest/ibc_bps_fee_test.go
@@ -89,18 +89,18 @@ func TestICS20BPSFees(t *testing.T) {
 	require.NoError(t, err, "failed to execute configure minter controller tx")
 
 	_, err = nobleValidator.ExecTx(ctx, gw.fiatTfRoles.MinterController.KeyName(),
-		"fiat-tokenfactory", "configure-minter", gw.fiatTfRoles.Minter.FormattedAddress(), "1000000000000"+denomMetadataDrachma.Base, "-b", "block",
+		"fiat-tokenfactory", "configure-minter", gw.fiatTfRoles.Minter.FormattedAddress(), "1000000000000"+denomMetadataUsdc.Base, "-b", "block",
 	)
 	require.NoError(t, err, "failed to execute configure minter tx")
 
 	_, err = nobleValidator.ExecTx(ctx, gw.fiatTfRoles.Minter.KeyName(),
-		"fiat-tokenfactory", "mint", gw.extraWallets.User.FormattedAddress(), "1000000000000"+denomMetadataDrachma.Base, "-b", "block",
+		"fiat-tokenfactory", "mint", gw.extraWallets.User.FormattedAddress(), "1000000000000"+denomMetadataUsdc.Base, "-b", "block",
 	)
 	require.NoError(t, err, "failed to execute mint to user tx")
 
-	userBalance, err := noble.GetBalance(ctx, gw.extraWallets.User.FormattedAddress(), denomMetadataDrachma.Base)
+	userBalance, err := noble.GetBalance(ctx, gw.extraWallets.User.FormattedAddress(), denomMetadataUsdc.Base)
 	require.NoError(t, err, "failed to get user balance")
-	require.Equalf(t, int64(1000000000000), userBalance, "failed to mint %s to user", denomMetadataDrachma.Base)
+	require.Equalf(t, int64(1000000000000), userBalance, "failed to mint %s to user", denomMetadataUsdc.Base)
 
 	nobleChans, err := r.GetChannels(ctx, eRep, noble.Config().ChainID)
 	require.NoError(t, err, "failed to get noble channels")
@@ -119,7 +119,7 @@ func TestICS20BPSFees(t *testing.T) {
 	// First, test BPS below max fees
 	tx, err := noble.SendIBCTransfer(ctx, nobleChan.ChannelID, gw.extraWallets.User.KeyName(), ibc.WalletAmount{
 		Address: gaiaReceiver,
-		Denom:   denomMetadataDrachma.Base,
+		Denom:   denomMetadataUsdc.Base,
 		Amount:  100000000,
 	}, ibc.TransferOptions{})
 	require.NoError(t, err, "failed to send ibc transfer from noble")
@@ -127,11 +127,11 @@ func TestICS20BPSFees(t *testing.T) {
 	_, err = testutil.PollForAck(ctx, noble, height, height+10, tx.Packet)
 	require.NoError(t, err, "failed to find ack for ibc transfer")
 
-	userBalance, err = noble.GetBalance(ctx, gw.extraWallets.User.FormattedAddress(), denomMetadataDrachma.Base)
+	userBalance, err = noble.GetBalance(ctx, gw.extraWallets.User.FormattedAddress(), denomMetadataUsdc.Base)
 	require.NoError(t, err, "failed to get user balance")
 	require.Equal(t, int64(999900000000), userBalance, "user balance is incorrect")
 
-	prefixedDenom := transfertypes.GetPrefixedDenom(nobleChan.Counterparty.PortID, nobleChan.Counterparty.ChannelID, denomMetadataDrachma.Base)
+	prefixedDenom := transfertypes.GetPrefixedDenom(nobleChan.Counterparty.PortID, nobleChan.Counterparty.ChannelID, denomMetadataUsdc.Base)
 	denomTrace := transfertypes.ParseDenomTrace(prefixedDenom)
 	ibcDenom := denomTrace.IBCDenom()
 
@@ -141,14 +141,14 @@ func TestICS20BPSFees(t *testing.T) {
 	require.Equal(t, int64(99990000), receiverBalance, "receiver balance incorrect")
 
 	// of the 10000 taken as fees, 80% goes to distribution entity (8000)
-	distributionEntityBalance, err := noble.GetBalance(ctx, gw.paramAuthority.FormattedAddress(), denomMetadataDrachma.Base)
+	distributionEntityBalance, err := noble.GetBalance(ctx, gw.paramAuthority.FormattedAddress(), denomMetadataUsdc.Base)
 	require.NoError(t, err, "failed to get distribution entity balance")
 	require.Equal(t, int64(8000), distributionEntityBalance, "distribution entity balance incorrect")
 
 	// Now test max fee
 	tx, err = noble.SendIBCTransfer(ctx, nobleChan.ChannelID, gw.extraWallets.User.FormattedAddress(), ibc.WalletAmount{
 		Address: gaiaReceiver,
-		Denom:   denomMetadataDrachma.Base,
+		Denom:   denomMetadataUsdc.Base,
 		Amount:  100000000000,
 	}, ibc.TransferOptions{})
 	require.NoError(t, err, "failed to send ibc transfer from noble")
@@ -157,7 +157,7 @@ func TestICS20BPSFees(t *testing.T) {
 	require.NoError(t, err, "failed to find ack for ibc transfer")
 
 	// 999900000000 user balance from prior test, now subtract 100000000000 = 899900000000
-	userBalance, err = noble.GetBalance(ctx, gw.extraWallets.User.FormattedAddress(), denomMetadataDrachma.Base)
+	userBalance, err = noble.GetBalance(ctx, gw.extraWallets.User.FormattedAddress(), denomMetadataUsdc.Base)
 	require.NoError(t, err, "failed to get user balance")
 	require.Equal(t, int64(899900000000), userBalance, "user balance is incorrect")
 
@@ -168,7 +168,7 @@ func TestICS20BPSFees(t *testing.T) {
 	require.Equal(t, int64(100094990000), receiverBalance, "receiver balance incorrect")
 
 	// prior balance 8000, add 80% of the 5000000 fee (4000000) = 4008000
-	distributionEntityBalance, err = noble.GetBalance(ctx, gw.paramAuthority.FormattedAddress(), denomMetadataDrachma.Base)
+	distributionEntityBalance, err = noble.GetBalance(ctx, gw.paramAuthority.FormattedAddress(), denomMetadataUsdc.Base)
 	require.NoError(t, err, "failed to get distribution entity balance")
 	require.Equal(t, int64(4008000), distributionEntityBalance, "distribution entity balance incorrect")
 

--- a/interchaintest/noble_test.go
+++ b/interchaintest/noble_test.go
@@ -57,12 +57,12 @@ func TestNobleChain(t *testing.T) {
 
 	t.Run("tokenfactory", func(t *testing.T) {
 		t.Parallel()
-		nobleTokenfactory_e2e(t, ctx, "tokenfactory", denomMetadataRupee.Base, noble, gw.tfRoles, gw.extraWallets)
+		nobleTokenfactory_e2e(t, ctx, "tokenfactory", denomMetadataFrienzies.Base, noble, gw.tfRoles, gw.extraWallets)
 	})
 
 	t.Run("fiat-tokenfactory", func(t *testing.T) {
 		t.Parallel()
-		nobleTokenfactory_e2e(t, ctx, "fiat-tokenfactory", denomMetadataDrachma.Base, noble, gw.fiatTfRoles, gw.extraWallets)
+		nobleTokenfactory_e2e(t, ctx, "fiat-tokenfactory", denomMetadataUsdc.Base, noble, gw.fiatTfRoles, gw.extraWallets)
 	})
 }
 

--- a/interchaintest/upgrade_argon_test.go
+++ b/interchaintest/upgrade_argon_test.go
@@ -173,7 +173,7 @@ func testPostArgonUpgradeTestnet(
 
 	cctpModuleAccount := authtypes.NewModuleAddress(cctptypes.ModuleName).String()
 
-	// we don't have access to the fiat tokenfactory owner, so this fails.
+	// by using mock images `mock-v2.0.0` or `mock-v0.4.2`, we have access to the fiat-tokenfactory owner accout
 	_, err = val.ExecTx(ctx, fiatOwner.KeyName(),
 		"fiat-tokenfactory", "update-master-minter", fiatMasterMinter.FormattedAddress(), "-b", "block")
 	require.NoError(t, err, "failed to execute update master minter tx")

--- a/interchaintest/upgrade_argon_test.go
+++ b/interchaintest/upgrade_argon_test.go
@@ -90,6 +90,7 @@ func testPostArgonUpgradeTestnet(
 	err = json.Unmarshal(queryRolesResults, &cctpRoles)
 	require.NoError(t, err, "failed to unmarshall cctp roles")
 
+	// For CI testing purposes, the paramauthority and cctp owner are the same.
 	require.Equal(t, paramAuthority.FormattedAddress(), cctpRoles.Owner)
 	require.Equal(t, cctpAttesterManager.FormattedAddress(), cctpRoles.AttesterManager)
 	require.Equal(t, cctpTokenController.FormattedAddress(), cctpRoles.TokenController)
@@ -162,7 +163,7 @@ func testPostArgonUpgradeTestnet(
 			From:         cctpTokenController.FormattedAddress(),
 			RemoteDomain: 0,
 			RemoteToken:  burnToken,
-			LocalToken:   denomMetadataDrachma.Base,
+			LocalToken:   denomMetadataUsdc.Base,
 		},
 	)
 	require.NoError(t, err, "error submitting add token pair tx")
@@ -183,7 +184,7 @@ func testPostArgonUpgradeTestnet(
 	require.NoError(t, err, "failed to execute configure minter controller tx")
 
 	_, err = val.ExecTx(ctx, fiatMinterController.KeyName(),
-		"fiat-tokenfactory", "configure-minter", cctpModuleAccount, "1000000"+denomMetadataDrachma.Base, "-b", "block",
+		"fiat-tokenfactory", "configure-minter", cctpModuleAccount, "1000000"+denomMetadataUsdc.Base, "-b", "block",
 	)
 	require.NoError(t, err, "failed to execute configure minter tx")
 
@@ -268,7 +269,7 @@ func testPostArgonUpgradeTestnet(
 
 	t.Logf("CCTP burn message successfully received: %s", tx.TxHash)
 
-	balance, err := noble.GetBalance(ctx, nobleReceiver, denomMetadataDrachma.Base)
+	balance, err := noble.GetBalance(ctx, nobleReceiver, denomMetadataUsdc.Base)
 	require.NoError(t, err)
 
 	require.Equal(t, int64(1000000), balance)

--- a/interchaintest/upgrade_argon_test.go
+++ b/interchaintest/upgrade_argon_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func testPostArgonUpgradeTestnet(
+func testPostArgonUpgrade(
 	t *testing.T,
 	ctx context.Context,
 	noble *cosmos.CosmosChain,

--- a/interchaintest/upgrade_grand-1_test.go
+++ b/interchaintest/upgrade_grand-1_test.go
@@ -62,7 +62,7 @@ func TestGrand1ChainUpgrade(t *testing.T) {
 		{
 			upgradeName: "v4.0.0-rc0",
 			image:       ghcrImage("v4.0.0-rc0"),
-			postUpgrade: testPostArgonUpgradeTestnet,
+			postUpgrade: testPostArgonUpgrade,
 		},
 	}
 

--- a/interchaintest/upgrade_grand-1_test.go
+++ b/interchaintest/upgrade_grand-1_test.go
@@ -22,7 +22,9 @@ func TestGrand1ChainUpgrade(t *testing.T) {
 			// As such, v0.4.2 was required to complete the upgrade, which changed the upgrade
 			// name in the code to "v0.4.1" as a workaround.
 			upgradeName: "v0.4.1",
-			image:       ghcrImage("dan-neon-control-test"), //this is an adjusted version that gives us control of the fiat-tokenfactory owner
+			// this is a mock image that gives us control of the
+			// fiat-tokenfactory owner for testing purposes (postUpgrade tests)
+			image: ghcrImage("mock-v0.4.2"),
 		},
 		{
 			upgradeName: "radon",
@@ -64,5 +66,5 @@ func TestGrand1ChainUpgrade(t *testing.T) {
 		},
 	}
 
-	testNobleChainUpgrade(t, grand1ChainID, grand1Genesis, denomMetadataDrachma, numVals, numFullNodes, grand1Upgrades)
+	testNobleChainUpgrade(t, grand1ChainID, grand1Genesis, denomMetadataUsdc, numVals, numFullNodes, grand1Upgrades)
 }

--- a/interchaintest/upgrade_noble-1_test.go
+++ b/interchaintest/upgrade_noble-1_test.go
@@ -18,7 +18,9 @@ func TestNoble1ChainUpgrade(t *testing.T) {
 	var noble1Upgrades = []chainUpgrade{
 		{
 			upgradeName: "neon",
-			image:       ghcrImage("v2.0.0"),
+			// this is a mock image that gives us control of the
+			// fiat-tokenfactory owner for testing purposes (postUpgrade tests)
+			image: ghcrImage("mock-v2.0.0"),
 		},
 		{
 			// omitting upgradeName due to huckleberry patch
@@ -35,8 +37,13 @@ func TestNoble1ChainUpgrade(t *testing.T) {
 		},
 		{
 			upgradeName: "argon",
-			image:       nobleImageInfo[0],
-			// NOTE: Add postUpgrade task once Neon mock image is created.
+			// this is a mock image that gives us control of the
+			// cctp owner for testing purposes (postUpgrade tests)
+			// (this is not needed for the `upgrade_grand-1_test` because
+			// the v4.0.0-alpha1 upgrade handler was only run in the testnet
+			// making the cctp owner the same as the paramauthority. This is
+			// not the case in mainnet; the cctp owner is a separate wallet)
+			image: ghcrImage("mock-v4.0.0"),
 		},
 	}
 

--- a/interchaintest/upgrade_noble-1_test.go
+++ b/interchaintest/upgrade_noble-1_test.go
@@ -43,7 +43,7 @@ func TestNoble1ChainUpgrade(t *testing.T) {
 			// the v4.0.0-alpha1 upgrade handler was only run in the testnet
 			// making the cctp owner the same as the paramauthority. This is
 			// not the case in mainnet; the cctp owner is a separate wallet)
-			image:       ghcrImage("john-prepare-argon"),
+			image:       ghcrImage("mock-v4.0.0"),
 			postUpgrade: testPostArgonUpgrade,
 		},
 	}

--- a/interchaintest/upgrade_noble-1_test.go
+++ b/interchaintest/upgrade_noble-1_test.go
@@ -43,7 +43,8 @@ func TestNoble1ChainUpgrade(t *testing.T) {
 			// the v4.0.0-alpha1 upgrade handler was only run in the testnet
 			// making the cctp owner the same as the paramauthority. This is
 			// not the case in mainnet; the cctp owner is a separate wallet)
-			image: ghcrImage("mock-v4.0.0"),
+			image:       ghcrImage("john-prepare-argon"),
+			postUpgrade: testPostArgonUpgrade,
 		},
 	}
 


### PR DESCRIPTION
This PR...

1) Changes the denoms used for the tests to match mainnet denoms (uusdc and frienzies)

2) Uses better named and more clear mock images `"mock-v0.4.2"`, `"mock-v2.0.0"` in the upgrade tests.

3) Adds back the argon post upgrade tests