### PR TITLE
chore: temporarily replace cctp dependency

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -40,7 +40,7 @@ jobs:
             echo "${{ secrets.GITAUTH }}" | base64 -d > ~/.ssh/id_ed25519
             chmod 600 ~/.ssh/id_ed25519
             apk add openssh
-            git config --global --add url."git@github.com:circlefin/noble-cctp.git".insteadOf "https://github.com/circlefin/noble-cctp"
+            git config --global --add url."git@github.com:circlefin/noble-cctp-private.git".insteadOf "https://github.com/circlefin/noble-cctp-private"
             ssh-keyscan github.com >> ~/.ssh/known_hosts
           binaries: |
             - /go/bin/nobled

--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -40,7 +40,7 @@ jobs:
             echo "${{ secrets.GITAUTH }}" | base64 -d > ~/.ssh/id_ed25519
             chmod 600 ~/.ssh/id_ed25519
             apk add openssh
-            git config --global --add url."git@github.com:circlefin/noble-cctp.git".insteadOf "https://github.com/circlefin/noble-cctp"
+            git config --global --add url."git@github.com:circlefin/noble-cctp-private.git".insteadOf "https://github.com/circlefin/noble-cctp-private"
             ssh-keyscan github.com >> ~/.ssh/known_hosts
           binaries: |
             - /go/bin/nobled

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -34,7 +34,7 @@ jobs:
             echo "${{ secrets.GITAUTH }}" | base64 -d > ~/.ssh/id_ed25519
             chmod 600 ~/.ssh/id_ed25519
             apk add openssh
-            git config --global --add url."git@github.com:circlefin/noble-cctp.git".insteadOf "https://github.com/circlefin/noble-cctp"
+            git config --global --add url."git@github.com:circlefin/noble-cctp-private.git".insteadOf "https://github.com/circlefin/noble-cctp-private"
             ssh-keyscan github.com >> ~/.ssh/known_hosts
           binaries: |
             - /go/bin/nobled
@@ -65,7 +65,7 @@ jobs:
         chmod 600 ~/.ssh/id_ed25519
         ssh-keyscan github.com >> ~/.ssh/known_hosts
         export GOPRIVATE=github.com/circlefin/noble-cctp
-        git config --global --add url."git@github.com:circlefin/noble-cctp.git".insteadOf "https://github.com/circlefin/noble-cctp"
+        git config --global --add url."git@github.com:circlefin/noble-cctp-private.git".insteadOf "https://github.com/circlefin/noble-cctp-private"
 
     - name: Generate matrix
       id: set-matrix
@@ -101,7 +101,7 @@ jobs:
           chmod 600 ~/.ssh/id_ed25519
           ssh-keyscan github.com >> ~/.ssh/known_hosts
           export GOPRIVATE=github.com/circlefin/noble-cctp
-          git config --global --add url."git@github.com:circlefin/noble-cctp.git".insteadOf "https://github.com/circlefin/noble-cctp"
+          git config --global --add url."git@github.com:circlefin/noble-cctp-private.git".insteadOf "https://github.com/circlefin/noble-cctp-private"
 
       - name: Download Tarball Artifact
         uses: actions/download-artifact@v3

--- a/.github/workflows/simulation-tests.yaml
+++ b/.github/workflows/simulation-tests.yaml
@@ -22,7 +22,7 @@ jobs:
           chmod 600 ~/.ssh/id_ed25519
           ssh-keyscan github.com >> ~/.ssh/known_hosts
           export GOPRIVATE=github.com/circlefin/noble-cctp
-          git config --global --add url."git@github.com:circlefin/noble-cctp.git".insteadOf "https://github.com/circlefin/noble-cctp"
+          git config --global --add url."git@github.com:circlefin/noble-cctp-private.git".insteadOf "https://github.com/circlefin/noble-cctp-private"
 
       - name: Run Unit Tests
         run: go test -bench BenchmarkSimulation ./app

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -22,7 +22,7 @@ jobs:
           chmod 600 ~/.ssh/id_ed25519
           ssh-keyscan github.com >> ~/.ssh/known_hosts
           export GOPRIVATE=github.com/circlefin/noble-cctp
-          git config --global --add url."git@github.com:circlefin/noble-cctp.git".insteadOf "https://github.com/circlefin/noble-cctp"
+          git config --global --add url."git@github.com:circlefin/noble-cctp-private.git".insteadOf "https://github.com/circlefin/noble-cctp-private"
 
       - name: Run Unit Tests
         run: go test -v ./...

--- a/go.mod
+++ b/go.mod
@@ -153,6 +153,9 @@ replace (
 	// use cosmos compatible ChainSafe/go-schnorrkel
 	github.com/ChainSafe/go-schnorrkel => github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d
 
+	// temporarily replace circlefin/noble-cctp before open sourcing
+	github.com/circlefin/noble-cctp => github.com/circlefin/noble-cctp-private v0.0.0-20231108011259-7c5206df02dc
+
 	// use macos sonoma compatible cosmos/ledger-cosmos-go
 	github.com/cosmos/ledger-cosmos-go => github.com/cosmos/ledger-cosmos-go v0.12.4
 

--- a/go.sum
+++ b/go.sum
@@ -183,8 +183,8 @@ github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-github.com/circlefin/noble-cctp v0.0.0-20231027180137-dce662fac8c2 h1:y8YNxzzsMwysHdPEyqJgWbuez/VbgDEhfpcK6nu0oCk=
-github.com/circlefin/noble-cctp v0.0.0-20231027180137-dce662fac8c2/go.mod h1:ssEHJqFI1f4a5sLtZ7qeYJ7/75LzDgzbBv4C9as3y3w=
+github.com/circlefin/noble-cctp-private v0.0.0-20231108011259-7c5206df02dc h1:FWkEwL+lIIQa8pM8pk0fPSzjgelrUimtspG6RGh0YGs=
+github.com/circlefin/noble-cctp-private v0.0.0-20231108011259-7c5206df02dc/go.mod h1:ssEHJqFI1f4a5sLtZ7qeYJ7/75LzDgzbBv4C9as3y3w=
 github.com/circlefin/noble-fiattokenfactory v0.0.0-20231026180023-32fd993c1f60 h1:jzokwZGplxSR9eQ231Sd83sAKo/08l4Ew8i+6qyJAKs=
 github.com/circlefin/noble-fiattokenfactory v0.0.0-20231026180023-32fd993c1f60/go.mod h1:rcUYSPnkN4M+epaMh2Y31V16rMDFQiY+OjRF+dwHDxE=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=

--- a/interchaintest/go.mod
+++ b/interchaintest/go.mod
@@ -185,6 +185,9 @@ replace (
 	// use cosmos compatible ChainSafe/go-schnorrkel
 	github.com/ChainSafe/go-schnorrkel => github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d
 
+	// temporarily replace circlefin/noble-cctp before open sourcing
+	github.com/circlefin/noble-cctp => github.com/circlefin/noble-cctp-private v0.0.0-20231108011259-7c5206df02dc
+
 	// use cosmos flavored gogo/protobuf
 	// https://github.com/cosmos/cosmos-sdk/issues/8469
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1

--- a/interchaintest/go.sum
+++ b/interchaintest/go.sum
@@ -189,8 +189,8 @@ github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-github.com/circlefin/noble-cctp v0.0.0-20231027180137-dce662fac8c2 h1:y8YNxzzsMwysHdPEyqJgWbuez/VbgDEhfpcK6nu0oCk=
-github.com/circlefin/noble-cctp v0.0.0-20231027180137-dce662fac8c2/go.mod h1:ssEHJqFI1f4a5sLtZ7qeYJ7/75LzDgzbBv4C9as3y3w=
+github.com/circlefin/noble-cctp-private v0.0.0-20231108011259-7c5206df02dc h1:FWkEwL+lIIQa8pM8pk0fPSzjgelrUimtspG6RGh0YGs=
+github.com/circlefin/noble-cctp-private v0.0.0-20231108011259-7c5206df02dc/go.mod h1:ssEHJqFI1f4a5sLtZ7qeYJ7/75LzDgzbBv4C9as3y3w=
 github.com/circlefin/noble-fiattokenfactory v0.0.0-20231026180023-32fd993c1f60 h1:jzokwZGplxSR9eQ231Sd83sAKo/08l4Ew8i+6qyJAKs=
 github.com/circlefin/noble-fiattokenfactory v0.0.0-20231026180023-32fd993c1f60/go.mod h1:rcUYSPnkN4M+epaMh2Y31V16rMDFQiY+OjRF+dwHDxE=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=


### PR DESCRIPTION
This PR temporarily replaces the CCTP dependency so that we can continue development while Circle open sources the codebase. It is planned to revert these changes once the repository is open sourced!